### PR TITLE
feat: basic implementation for Dependency Track

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ All parameters are cli-flags.
 | `git-author-email` | `true` when `git` target is used. | `""` | Author email to use for Git-Commits. |
 | `pod-label-selector` | `false` | `""` | Kubernetes Label-Selector for pods. |
 | `namespace-label-selector` | `false` | `""` | Kubernetes Label-Selector for namespaces. |
+| `dtrack-base-url` | `true` when `dtrack` target is used | `""` | Dependency-Track base URL, e.g. 'https://dtrack.example.com' |
+| `dtrack-api-key` | `true` when `dtrack` target is used | `""` | Dependency-Track API key |
 
 The flags can be configured as args or as environment-variables prefixed with `SBOM_` to inject sensitive configs as secret values.
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.17
 require (
 	github.com/anchore/syft v0.36.0
 	github.com/docker/cli v20.10.12+incompatible
-	github.com/google/uuid v1.3.0
 	github.com/novln/docker-parser v1.0.0
 	github.com/nscuro/dtrack-client v0.3.0
 	github.com/onsi/ginkgo/v2 v2.1.1
@@ -46,6 +45,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-restruct/restruct v1.2.0-alpha // indirect
 	github.com/golang/snappy v0.0.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.17
 require (
 	github.com/anchore/syft v0.36.0
 	github.com/docker/cli v20.10.12+incompatible
+	github.com/google/uuid v1.3.0
 	github.com/novln/docker-parser v1.0.0
+	github.com/nscuro/dtrack-client v0.3.0
 	github.com/onsi/ginkgo/v2 v2.1.1
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.8.1
@@ -44,7 +46,6 @@ require (
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-restruct/restruct v1.2.0-alpha // indirect
 	github.com/golang/snappy v0.0.3 // indirect
-	github.com/google/uuid v1.2.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -520,8 +520,9 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
@@ -605,6 +606,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
+github.com/jarcoal/httpmock v1.0.8 h1:8kI16SoO6LQKgPE7PvQuV+YuD/inwHd7fOOe2zMbo4k=
+github.com/jarcoal/httpmock v1.0.8/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
@@ -735,6 +738,8 @@ github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/novln/docker-parser v1.0.0 h1:PjEBd9QnKixcWczNGyEdfUrP6GR0YUilAqG7Wksg3uc=
 github.com/novln/docker-parser v1.0.0/go.mod h1:oCeM32fsoUwkwByB5wVjsrsVQySzPWkl3JdlTn1txpE=
+github.com/nscuro/dtrack-client v0.3.0 h1:d0mlxHzgUA4HDtrGMlaseWZsu28zKf0Wgy30XYN5oxE=
+github.com/nscuro/dtrack-client v0.3.0/go.mod h1:g/zi6OOaWuk0Uhhq6APF3fet7QGHeK+OTBBfalnBGBA=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/internal/config.go
+++ b/internal/config.go
@@ -15,6 +15,6 @@ var (
 	ConfigKeyGitAuthorEmail         = "git-author-email"
 	ConfigKeyPodLabelSelector       = "pod-label-selector"
 	ConfigKeyNamespaceLabelSelector = "namespace-label-selector"
-	ConfigKeyDependencaTrackBaseUrl = "dtrack-base-url"
-	ConfigKeyDependencaTrackApiKey  = "dtrack-api-key"
+	ConfigKeyDependencyTrackBaseUrl = "dtrack-base-url"
+	ConfigKeyDependencyTrackApiKey  = "dtrack-api-key"
 )

--- a/internal/config.go
+++ b/internal/config.go
@@ -15,4 +15,6 @@ var (
 	ConfigKeyGitAuthorEmail         = "git-author-email"
 	ConfigKeyPodLabelSelector       = "pod-label-selector"
 	ConfigKeyNamespaceLabelSelector = "namespace-label-selector"
+	ConfigKeyDependencaTrackBaseUrl = "dtrack-base-url"
+	ConfigKeyDependencaTrackApiKey  = "dtrack-api-key"
 )

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -68,7 +68,7 @@ func (c *CronService) runBackgroundService() {
 		}
 
 		for _, t := range c.targets {
-			t.ProcessSbom(image.ImageID, sbom)
+			t.ProcessSbom(image, sbom)
 		}
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -90,7 +90,7 @@ func initTargets(targetKeys []string) []target.Target {
 			err = t.ValidateConfig()
 			targets = append(targets, t)
 		} else if ta == "dtrack" {
-			t := target.NewDependencaTrackTarget()
+			t := target.NewDependencyTrackTarget()
 			err = t.ValidateConfig()
 			targets = append(targets, t)
 		} else {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -89,6 +89,10 @@ func initTargets(targetKeys []string) []target.Target {
 			t := target.NewGitTarget()
 			err = t.ValidateConfig()
 			targets = append(targets, t)
+		} else if ta == "dtrack" {
+			t := target.NewDependencaTrackTarget()
+			err = t.ValidateConfig()
+			targets = append(targets, t)
 		} else {
 			logrus.Fatalf("Unknown target %s", ta)
 		}

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -16,6 +16,7 @@ import (
 )
 
 type ContainerImage struct {
+	Image   string
 	ImageID string
 	Auth    []byte
 	Pods    []corev1.Pod
@@ -106,7 +107,7 @@ func (client *KubeClient) LoadImageInfos(namespaces []corev1.Namespace, podLabel
 					if !client.hasAnnotation(annotations, c) {
 						img, ok := images[c.ImageID]
 						if !ok {
-							img = ContainerImage{ImageID: c.ImageID, Auth: pullSecrets, Pods: []corev1.Pod{}}
+							img = ContainerImage{Image: c.Image, ImageID: c.ImageID, Auth: pullSecrets, Pods: []corev1.Pod{}}
 						}
 
 						img.Pods = append(img.Pods, pod)

--- a/internal/target/dtrack_target.go
+++ b/internal/target/dtrack_target.go
@@ -44,15 +44,12 @@ func (g *DependencyTrackTarget) Initialize() {
 func (g *DependencyTrackTarget) ProcessSbom(image kubernetes.ContainerImage, sbom string) {
 	fullRef, err := parser.Parse(image.Image)
 	if err != nil {
-		logrus.WithError(err).Errorf("Could not parse imageID %s", image.ImageID)
+		logrus.WithError(err).Errorf("Could not parse image %s", image.Image)
 		return
 	}
 
 	imageName := fullRef.Repository()
 	tagName := fullRef.Tag()
-	if tagName == "" {
-		tagName = "latest"
-	}
 
 	if sbom == "" {
 		logrus.Infof("Empty SBOM - skip image (image=%s)", image.ImageID)

--- a/internal/target/dtrack_target.go
+++ b/internal/target/dtrack_target.go
@@ -14,32 +14,32 @@ import (
 	"github.com/ckotzbauer/sbom-operator/internal"
 )
 
-type DependencaTrackTarget struct {
+type DependencyTrackTarget struct {
 	baseUrl        string
 	apiKey         string
 	imageToProject map[string]uuid.UUID
 }
 
-func NewDependencaTrackTarget() *DependencaTrackTarget {
-	baseUrl := viper.GetString(internal.ConfigKeyDependencaTrackBaseUrl)
-	apiKey := viper.GetString(internal.ConfigKeyDependencaTrackApiKey)
-	return &DependencaTrackTarget{
+func NewDependencyTrackTarget() *DependencyTrackTarget {
+	baseUrl := viper.GetString(internal.ConfigKeyDependencyTrackBaseUrl)
+	apiKey := viper.GetString(internal.ConfigKeyDependencyTrackApiKey)
+	return &DependencyTrackTarget{
 		baseUrl: baseUrl,
 		apiKey:  apiKey,
 	}
 }
 
-func (g *DependencaTrackTarget) ValidateConfig() error {
+func (g *DependencyTrackTarget) ValidateConfig() error {
 	if g.baseUrl == "" {
-		return fmt.Errorf("%s is empty", internal.ConfigKeyDependencaTrackBaseUrl)
+		return fmt.Errorf("%s is empty", internal.ConfigKeyDependencyTrackBaseUrl)
 	}
 	if g.apiKey == "" {
-		return fmt.Errorf("%s is empty", internal.ConfigKeyDependencaTrackApiKey)
+		return fmt.Errorf("%s is empty", internal.ConfigKeyDependencyTrackApiKey)
 	}
 	return nil
 }
 
-func (g *DependencaTrackTarget) Initialize() {
+func (g *DependencyTrackTarget) Initialize() {
 	client, _ := dtrack.NewClient(g.baseUrl, dtrack.WithAPIKey(g.apiKey))
 	g.imageToProject = make(map[string]uuid.UUID)
 
@@ -71,7 +71,7 @@ func (g *DependencaTrackTarget) Initialize() {
 	}
 }
 
-func (g *DependencaTrackTarget) ProcessSbom(imageID, sbom string) {
+func (g *DependencyTrackTarget) ProcessSbom(imageID, sbom string) {
 	if sbom == "" {
 		logrus.Infof("Empty SBOM - skip image (image=%s)", imageID)
 		return
@@ -119,6 +119,6 @@ func (g *DependencaTrackTarget) ProcessSbom(imageID, sbom string) {
 	logrus.Infof("Uploaded SBOM (upload-token=%s)", uploadToken)
 }
 
-func (g *DependencaTrackTarget) Cleanup(allImages []string) {
+func (g *DependencyTrackTarget) Cleanup(allImages []string) {
 	g.imageToProject = nil
 }

--- a/internal/target/dtrack_target.go
+++ b/internal/target/dtrack_target.go
@@ -1,0 +1,112 @@
+package target
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	dtrack "github.com/nscuro/dtrack-client"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+
+	"github.com/ckotzbauer/sbom-operator/internal"
+)
+
+type DependencaTrackTarget struct {
+	baseUrl        string
+	apiKey         string
+	imageToProject map[string]uuid.UUID
+}
+
+func NewDependencaTrackTarget() *DependencaTrackTarget {
+	baseUrl := viper.GetString(internal.ConfigKeyDependencaTrackBaseUrl)
+	apiKey := viper.GetString(internal.ConfigKeyDependencaTrackApiKey)
+	return &DependencaTrackTarget{
+		baseUrl: baseUrl,
+		apiKey:  apiKey,
+	}
+}
+
+func (g *DependencaTrackTarget) ValidateConfig() error {
+	if g.baseUrl == "" {
+		return fmt.Errorf("%s is empty", internal.ConfigKeyDependencaTrackBaseUrl)
+	}
+	if g.apiKey == "" {
+		return fmt.Errorf("%s is empty", internal.ConfigKeyDependencaTrackApiKey)
+	}
+	return nil
+}
+
+func (g *DependencaTrackTarget) Initialize() {
+	client, _ := dtrack.NewClient(g.baseUrl, dtrack.WithAPIKey(g.apiKey))
+	projectsPage, err := client.Project.GetAll(context.TODO(), dtrack.PageOptions{
+		PageNumber: 1,
+		PageSize:   10,
+	})
+	if err != nil {
+		logrus.Errorf("Could not fetch projects: %v", err)
+	}
+
+	g.imageToProject = make(map[string]uuid.UUID)
+	for _, project := range projectsPage.Projects {
+		for _, property := range project.Properties {
+			if property.Name == "image-name" {
+				g.imageToProject[property.Value] = project.UUID
+			}
+		}
+	}
+}
+
+func (g *DependencaTrackTarget) ProcessSbom(imageID, sbom string) {
+	if sbom == "" {
+		logrus.Infof("Empty SBOM - skip image (image=%s)", imageID)
+		return
+	}
+
+	client, _ := dtrack.NewClient(g.baseUrl, dtrack.WithAPIKey(g.apiKey))
+	logrus.Infof("Sending SBOM to Dependency Track (image=%s)", imageID)
+
+	if !strings.ContainsRune(imageID, '@') {
+		logrus.Warnf("Image id %s does not contain an @sha256", imageID)
+		return
+	}
+	imageSplit := strings.Split(imageID, "@")
+	imageName := imageSplit[0]
+
+	projectId := g.imageToProject[imageName]
+	if projectId == uuid.Nil {
+		project, err := client.Project.Create(context.TODO(),
+			dtrack.Project{
+				Active:     true,
+				Classifier: "APPLICATION",
+				Name:       imageName,
+				Properties: []dtrack.ProjectProperty{
+					{Name: "image-name", Group: "container", Value: imageName, Type: "STRING"},
+				},
+				// TODO check if to add PURL: "pkg:docker/" + imageID,
+			})
+		if err != nil {
+			logrus.Errorf("Could not create project (%s): %v", imageName, err)
+		}
+		projectId = project.UUID
+		g.imageToProject[imageName] = projectId
+	}
+
+	if projectId == uuid.Nil {
+		logrus.Warnf("No project id for image %s", imageName)
+		return
+	}
+
+	sbomBase64 := base64.StdEncoding.EncodeToString([]byte(sbom))
+	uploadToken, err := client.BOM.Upload(context.TODO(), dtrack.BOMUploadRequest{ProjectUUID: &projectId, BOM: sbomBase64, AutoCreate: false})
+	if err != nil {
+		logrus.Errorf("Could not upload BOM: %v", err)
+	}
+	logrus.Infof("Uploaded SBOM (upload-token=%s)", uploadToken)
+}
+
+func (g *DependencaTrackTarget) Cleanup(allImages []string) {
+	g.imageToProject = nil
+}

--- a/internal/target/git_target.go
+++ b/internal/target/git_target.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ckotzbauer/sbom-operator/internal"
+	"github.com/ckotzbauer/sbom-operator/internal/kubernetes"
 	"github.com/ckotzbauer/sbom-operator/internal/syft"
 	"github.com/ckotzbauer/sbom-operator/internal/target/git"
 	"github.com/sirupsen/logrus"
@@ -79,7 +80,8 @@ func (g *GitTarget) Initialize() {
 		viper.GetString(internal.ConfigKeyGitBranch))
 }
 
-func (g *GitTarget) ProcessSbom(imageID, sbom string) {
+func (g *GitTarget) ProcessSbom(image kubernetes.ContainerImage, sbom string) {
+	imageID := image.ImageID
 	filePath := g.imageIDToFilePath(imageID)
 
 	dir := filepath.Dir(filePath)

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -1,8 +1,12 @@
 package target
 
+import (
+	"github.com/ckotzbauer/sbom-operator/internal/kubernetes"
+)
+
 type Target interface {
 	Initialize()
 	ValidateConfig() error
-	ProcessSbom(imageID, sbom string)
+	ProcessSbom(imageID kubernetes.ContainerImage, sbom string)
 	Cleanup(allImages []string)
 }

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&verbosity, internal.ConfigKeyVerbosity, "v", logrus.InfoLevel.String(), "Log-level (debug, info, warn, error, fatal, panic)")
 	rootCmd.PersistentFlags().StringVarP(&daemonCron, internal.ConfigKeyCron, "c", "@hourly", "Backround-Service interval (CRON)")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyFormat, "json", "SBOM-Format.")
-	rootCmd.PersistentFlags().StringSlice(internal.ConfigKeyTargets, []string{"git"}, "Targets for created SBOMs.")
+	rootCmd.PersistentFlags().StringSlice(internal.ConfigKeyTargets, []string{"git"}, "Targets for created SBOMs (git, dtrack).")
 	rootCmd.PersistentFlags().Bool(internal.ConfigKeyIgnoreAnnotations, false, "Force analyzing of all images, including those from annotated pods.")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyGitWorkingTree, "/work", "Directory to place the git-repo.")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyGitRepository, "", "Git-Repository-URL (HTTPS).")
@@ -57,6 +57,8 @@ func init() {
 	rootCmd.PersistentFlags().String(internal.ConfigKeyGitAuthorEmail, "", "Author email to use for Git-Commits.")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyPodLabelSelector, "", "Kubernetes Label-Selector for pods.")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyNamespaceLabelSelector, "", "Kubernetes Label-Selector for namespaces.")
+	rootCmd.PersistentFlags().String(internal.ConfigKeyDependencaTrackBaseUrl, "", "Dependency-Track base URL, e.g. 'https://dtrack.example.com'")
+	rootCmd.PersistentFlags().String(internal.ConfigKeyDependencaTrackApiKey, "", "Dependency-Track API key")
 }
 
 func initConfig() {

--- a/main.go
+++ b/main.go
@@ -57,8 +57,8 @@ func init() {
 	rootCmd.PersistentFlags().String(internal.ConfigKeyGitAuthorEmail, "", "Author email to use for Git-Commits.")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyPodLabelSelector, "", "Kubernetes Label-Selector for pods.")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyNamespaceLabelSelector, "", "Kubernetes Label-Selector for namespaces.")
-	rootCmd.PersistentFlags().String(internal.ConfigKeyDependencaTrackBaseUrl, "", "Dependency-Track base URL, e.g. 'https://dtrack.example.com'")
-	rootCmd.PersistentFlags().String(internal.ConfigKeyDependencaTrackApiKey, "", "Dependency-Track API key")
+	rootCmd.PersistentFlags().String(internal.ConfigKeyDependencyTrackBaseUrl, "", "Dependency-Track base URL, e.g. 'https://dtrack.example.com'")
+	rootCmd.PersistentFlags().String(internal.ConfigKeyDependencyTrackApiKey, "", "Dependency-Track API key")
 }
 
 func initConfig() {


### PR DESCRIPTION
This adds a basic implementation for sending data to [Dependency Track](https://dependencytrack.org/).

When launching the operator make sure to also set `--format=cyclonedx`

This is how the Dependency Track project is found:

* Search for project with the property "image-name" in the group "container" with the image name
* If found use this project, if not found create a new project with the image name as the project name + also add the property "image-name"

See #5 