### PR TITLE
feat: delete unused images from Dependency Track

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ All parameters are cli-flags.
 | `namespace-label-selector` | `false` | `""` | Kubernetes Label-Selector for namespaces. |
 | `dtrack-base-url` | `true` when `dtrack` target is used | `""` | Dependency-Track base URL, e.g. 'https://dtrack.example.com' |
 | `dtrack-api-key` | `true` when `dtrack` target is used | `""` | Dependency-Track API key |
+| `kubernetes-cluster-id` | `false` | `"default"` | Kubernetes Cluster ID (to be used in Dependency-Track)
 
 The flags can be configured as args or as environment-variables prefixed with `SBOM_` to inject sensitive configs as secret values.
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -17,4 +17,5 @@ var (
 	ConfigKeyNamespaceLabelSelector = "namespace-label-selector"
 	ConfigKeyDependencyTrackBaseUrl = "dtrack-base-url"
 	ConfigKeyDependencyTrackApiKey  = "dtrack-api-key"
+	ConfigKeyKubernetesClusterId    = "kubernetes-cluster-id"
 )

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -82,9 +82,9 @@ func (client *KubeClient) listPods(namespace, labelSelector string) []corev1.Pod
 	return list.Items
 }
 
-func (client *KubeClient) LoadImageInfos(namespaces []corev1.Namespace, podLabelSelector string) (map[string]ContainerImage, []string) {
+func (client *KubeClient) LoadImageInfos(namespaces []corev1.Namespace, podLabelSelector string) (map[string]ContainerImage, []ContainerImage) {
 	images := map[string]ContainerImage{}
-	allImages := []string{}
+	allImages := []ContainerImage{}
 
 	for _, ns := range namespaces {
 		pods := client.listPods(ns.Name, podLabelSelector)
@@ -119,11 +119,17 @@ func (client *KubeClient) LoadImageInfos(namespaces []corev1.Namespace, podLabel
 
 						img.Pods = append(img.Pods, pod)
 						images[c.ImageID] = img
+						allImages = append(allImages, img)
 					} else {
 						logrus.Debugf("Skip image %s", c.ImageID)
+						allImages = append(allImages, ContainerImage{
+							Image:      c.Image,
+							ImageID:    c.ImageID,
+							Auth:       pullSecrets,
+							LegacyAuth: legacy,
+							Pods:       []corev1.Pod{},
+						})
 					}
-
-					allImages = append(allImages, c.ImageID)
 				}
 			}
 		}

--- a/internal/target/dtrack_target.go
+++ b/internal/target/dtrack_target.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	parser "github.com/novln/docker-parser"
 	dtrack "github.com/nscuro/dtrack-client"
@@ -15,16 +16,24 @@ import (
 )
 
 type DependencyTrackTarget struct {
-	baseUrl string
-	apiKey  string
+	baseUrl      string
+	apiKey       string
+	k8sClusterId string
 }
+
+const (
+	kubernetesCluster = "kubernetes-cluster"
+	sbomOperator      = "sbom-operator"
+)
 
 func NewDependencyTrackTarget() *DependencyTrackTarget {
 	baseUrl := viper.GetString(internal.ConfigKeyDependencyTrackBaseUrl)
 	apiKey := viper.GetString(internal.ConfigKeyDependencyTrackApiKey)
+	k8sClusterId := viper.GetString(internal.ConfigKeyKubernetesClusterId)
 	return &DependencyTrackTarget{
-		baseUrl: baseUrl,
-		apiKey:  apiKey,
+		baseUrl:      baseUrl,
+		apiKey:       apiKey,
+		k8sClusterId: k8sClusterId,
 	}
 }
 
@@ -42,14 +51,14 @@ func (g *DependencyTrackTarget) Initialize() {
 }
 
 func (g *DependencyTrackTarget) ProcessSbom(image kubernetes.ContainerImage, sbom string) error {
-	fullRef, err := parser.Parse(image.Image)
+	imageRef, err := parser.Parse(image.Image)
 	if err != nil {
 		logrus.WithError(err).Errorf("Could not parse image %s", image.Image)
 		return nil
 	}
 
-	imageName := fullRef.Repository()
-	tagName := fullRef.Tag()
+	projectName := imageRef.Repository()
+	version := imageRef.Tag()
 
 	if sbom == "" {
 		logrus.Infof("Empty SBOM - skip image (image=%s)", image.ImageID)
@@ -58,12 +67,12 @@ func (g *DependencyTrackTarget) ProcessSbom(image kubernetes.ContainerImage, sbo
 
 	client, _ := dtrack.NewClient(g.baseUrl, dtrack.WithAPIKey(g.apiKey))
 
-	logrus.Infof("Sending SBOM to Dependency Track (project=%s, version=%s)", imageName, tagName)
+	logrus.Infof("Sending SBOM to Dependency Track (project=%s, version=%s)", projectName, version)
 
 	sbomBase64 := base64.StdEncoding.EncodeToString([]byte(sbom))
 	uploadToken, err := client.BOM.Upload(
-		context.TODO(),
-		dtrack.BOMUploadRequest{ProjectName: imageName, ProjectVersion: tagName, AutoCreate: true, BOM: sbomBase64},
+		context.Background(),
+		dtrack.BOMUploadRequest{ProjectName: projectName, ProjectVersion: version, AutoCreate: true, BOM: sbomBase64},
 	)
 	if err != nil {
 		logrus.Errorf("Could not upload BOM: %v", err)
@@ -71,8 +80,116 @@ func (g *DependencyTrackTarget) ProcessSbom(image kubernetes.ContainerImage, sbo
 	}
 
 	logrus.Infof("Uploaded SBOM (upload-token=%s)", uploadToken)
+
+	project, err := client.Project.Lookup(context.Background(), projectName, version)
+	if err != nil {
+		logrus.Errorf("Could not find project: %v", err)
+		return err
+	}
+
+	kubernetesClusterTag := kubernetesCluster + "=" + g.k8sClusterId
+	if !containsTag(project.Tags, kubernetesClusterTag) {
+		project.Tags = append(project.Tags, dtrack.Tag{Name: kubernetesClusterTag})
+	}
+	if !containsTag(project.Tags, sbomOperator) {
+		project.Tags = append(project.Tags, dtrack.Tag{Name: sbomOperator})
+	}
+
+	_, err = client.Project.Update(context.Background(), *project)
+	if err != nil {
+		logrus.WithError(err).Errorf("Could not update project tags")
+	}
+
 	return nil
 }
 
 func (g *DependencyTrackTarget) Cleanup(allImages []string) {
+	client, _ := dtrack.NewClient(g.baseUrl, dtrack.WithAPIKey(g.apiKey))
+
+	var (
+		pageNumber = 1
+		pageSize   = 50
+	)
+
+	allImageRefs := make([]parser.Reference, len(allImages))
+	for _, image := range allImages {
+		ref, err := parser.Parse(image)
+		if err != nil {
+			logrus.WithError(err).Errorf("Could not parse image %s", image)
+			continue
+		}
+		allImageRefs = append(allImageRefs, *ref)
+	}
+
+	for {
+		projectsPage, err := client.Project.GetAll(context.Background(), dtrack.PageOptions{
+			PageNumber: pageNumber,
+			PageSize:   pageSize,
+		})
+		if err != nil {
+			logrus.Errorf("Could not load projects: %v", err)
+		}
+
+	projectLoop:
+		for _, project := range projectsPage.Projects {
+			currentImageName := fmt.Sprintf("%v:%v", project.Name, project.Version)
+
+			// Image used in current cluster
+			for _, image := range allImages {
+				if image == currentImageName {
+					continue projectLoop
+				}
+			}
+
+			// check all tags, remove the current cluster and aggregate a list of other clusters
+			otherClusterIds := []string{}
+			sbomOperatorPropFound := false
+			for _, tag := range project.Tags {
+				if strings.Index(tag.Name, kubernetesCluster) == 0 {
+					clusterId := string(tag.Name[len(kubernetesCluster)+1:])
+					if clusterId == g.k8sClusterId {
+						logrus.Infof("Removing %v=%v tag from project %v", kubernetesCluster, g.k8sClusterId, currentImageName)
+						project.Tags = removeTag(project.Tags, kubernetesCluster+"="+g.k8sClusterId)
+						client.Project.Update(context.Background(), project)
+					} else {
+						otherClusterIds = append(otherClusterIds, clusterId)
+					}
+				}
+				if tag.Name == sbomOperator {
+					sbomOperatorPropFound = true
+				}
+			}
+
+			// if not in other cluster delete the project
+			if sbomOperatorPropFound && len(otherClusterIds) == 0 {
+				logrus.Infof("Image not running in any cluster - removing %v", currentImageName)
+				client.Project.Delete(context.Background(), project.UUID)
+			}
+		}
+
+		if pageNumber*pageSize >= projectsPage.TotalCount {
+			break
+		}
+
+		pageNumber++
+	}
+}
+
+func containsTag(tags []dtrack.Tag, tagString string) bool {
+	for _, tag := range tags {
+		if tag.Name == tagString {
+			return true
+		}
+	}
+	return false
+}
+
+func removeTag(tags []dtrack.Tag, tagString string) []dtrack.Tag {
+	newTags := []dtrack.Tag{}
+	for _, tag := range tags {
+		if tag.Name != tagString {
+			newTags = append(newTags, tag)
+		}
+	}
+	return newTags
 }

--- a/internal/target/dtrack_target.go
+++ b/internal/target/dtrack_target.go
@@ -103,7 +103,7 @@ func (g *DependencyTrackTarget) ProcessSbom(image kubernetes.ContainerImage, sbo
 	return nil
 }
 
-func (g *DependencyTrackTarget) Cleanup(allImages []string) {
+func (g *DependencyTrackTarget) Cleanup(allImages []kubernetes.ContainerImage) {
 	client, _ := dtrack.NewClient(g.baseUrl, dtrack.WithAPIKey(g.apiKey))
 
 	var (
@@ -113,9 +113,9 @@ func (g *DependencyTrackTarget) Cleanup(allImages []string) {
 
 	allImageRefs := make([]parser.Reference, len(allImages))
 	for _, image := range allImages {
-		ref, err := parser.Parse(image)
+		ref, err := parser.Parse(image.Image)
 		if err != nil {
-			logrus.WithError(err).Errorf("Could not parse image %s", image)
+			logrus.WithError(err).Errorf("Could not parse image %s", image.Image)
 			continue
 		}
 		allImageRefs = append(allImageRefs, *ref)
@@ -136,7 +136,7 @@ func (g *DependencyTrackTarget) Cleanup(allImages []string) {
 
 			// Image used in current cluster
 			for _, image := range allImages {
-				if image == currentImageName {
+				if image.Image == currentImageName {
 					continue projectLoop
 				}
 			}

--- a/internal/target/git_target.go
+++ b/internal/target/git_target.go
@@ -99,7 +99,7 @@ func (g *GitTarget) ProcessSbom(image kubernetes.ContainerImage, sbom string) er
 	return g.gitAccount.CommitAll(g.workingTree, fmt.Sprintf("Created new SBOM for image %s", imageID))
 }
 
-func (g *GitTarget) Cleanup(allImages []string) {
+func (g *GitTarget) Cleanup(allImages []kubernetes.ContainerImage) {
 	logrus.Debug("Start to remove old SBOMs")
 	ignoreDirs := []string{".git"}
 
@@ -114,10 +114,10 @@ func (g *GitTarget) Cleanup(allImages []string) {
 	}
 }
 
-func (g *GitTarget) mapToFiles(allImages []string) []string {
+func (g *GitTarget) mapToFiles(allImages []kubernetes.ContainerImage) []string {
 	paths := []string{}
 	for _, img := range allImages {
-		paths = append(paths, g.imageIDToFilePath(img))
+		paths = append(paths, g.imageIDToFilePath(img.ImageID))
 	}
 
 	return paths

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -8,5 +8,5 @@ type Target interface {
 	Initialize()
 	ValidateConfig() error
 	ProcessSbom(image kubernetes.ContainerImage, sbom string) error
-	Cleanup(allImages []string)
+	Cleanup(allImages []kubernetes.ContainerImage)
 }

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ func init() {
 	rootCmd.PersistentFlags().String(internal.ConfigKeyNamespaceLabelSelector, "", "Kubernetes Label-Selector for namespaces.")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyDependencyTrackBaseUrl, "", "Dependency-Track base URL, e.g. 'https://dtrack.example.com'")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyDependencyTrackApiKey, "", "Dependency-Track API key")
+	rootCmd.PersistentFlags().String(internal.ConfigKeyKubernetesClusterId, "default", "Kubernetes Cluster ID")
 }
 
 func initConfig() {


### PR DESCRIPTION
This adds tags to the Dependency-Track projects to track which were
created by the SBOM operator. The following tags are created:

- sbom-operator
- kubernetes-cluster={kubernetes-cluster-id}

The `kubernetes-cluster-id` can be set via a command line parameter
(when not specified `default` is used).

This is how the tags look like in the Dependency-Track UI:
![image](https://user-images.githubusercontent.com/123199/157889649-bd5012f4-b534-4de1-9d69-8ca6a89d29bf.png)
You can use the tags to filter for images in a certain cluster

Closes #27