### PR TITLE
fix: Grant `watch` permissions on `Pods` to ServiceAccount

### DIFF
--- a/deploy/standard/rbac.yaml
+++ b/deploy/standard/rbac.yaml
@@ -28,6 +28,7 @@ rules:
   verbs:
   - get
   - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Informer that watch for pods required `watch` permissions.

Why:

This solves SBOM operator not able to watch pods and throwing this error:

```
time="2022-08-28T13:14:23Z" level=info msg="Built by: goreleaser"
time="2022-08-28T13:14:23Z" level=info msg="Go Version: go1.19"
time="2022-08-28T13:14:23Z" level=info msg="Webserver is running at port 8080"
time="2022-08-28T13:14:23Z" level=info msg="Wait for cache to be synced"
time="2022-08-28T13:14:24Z" level=info msg="Start pod-informer"
E0828 13:14:24.581869       1 reflector.go:138] k8s.io/client-go@v0.24.4/tools/cache/reflector.go:167: Failed to watch *v1.Pod: unknown (get pods)
time="2022-08-28T13:14:24Z" level=info msg="Finished cache sync"
E0828 13:14:26.069827       1 reflector.go:138] k8s.io/client-go@v0.24.4/tools/cache/reflector.go:167: Failed to watch *v1.Pod: unknown (get pods)
E0828 13:14:28.048791       1 reflector.go:138] k8s.io/client-go@v0.24.4/tools/cache/reflector.go:167: Failed to watch *v1.Pod: unknown (get pods)
E0828 13:14:34.068515       1 reflector.go:138] k8s.io/client-go@v0.24.4/tools/cache/reflector.go:167: Failed to watch *v1.Pod: unknown (get pods)
E0828 13:14:46.577715       1 reflector.go:138] k8s.io/client-go@v0.24.4/tools/cache/reflector.go:167: Failed to watch *v1.Pod: unknown (get pods)
```