### PR TITLE
feat(dtrack): expose mTLS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ not present in the cluster anymore are removed from the configured targets (exce
 | `dtrack-base-url` | `true` when `dtrack` target is used | `""` | Dependency-Track base URL, e.g. 'https://dtrack.example.com' |
 | `dtrack-api-key` | `true` when `dtrack` target is used | `""` | Dependency-Track API key |
 | `dtrack-label-tag-matcher` | `false` | `""` | Dependency-Track Pod-Label-Tag matcher regex |
+| `dtrack-ca-cert-file` | `false` | `""` | CA-Certificate filepath when using mTLS to connect to dtrack |
+| `dtrack-client-cert-file` | `true` when `dtrack-ca-cert-file` is provided | `""` | Client-Certificate filepath when using mTLS to connect to dtrack |
+| `dtrack-client-key-file` | `true` when `dtrack-ca-cert-file` is provided | `""` | Client-Key filepath when using mTLS to connect to dtrack |
 | `kubernetes-cluster-id` | `false` | `"default"` | Kubernetes Cluster ID (to be used in Dependency-Track or Job-Images) |
 
 Each image in the cluster is created as project with the full-image name (registry and image-path without tag) and the image-tag as project-version.

--- a/internal/config.go
+++ b/internal/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	DtrackBaseUrl           string   `yaml:"dtrackBaseUrl" env:"SBOM_DTRACK_BASE_URL" flag:"dtrack-base-url"`
 	DtrackApiKey            string   `yaml:"dtrackApiKey" env:"SBOM_DTRACK_API_KEY" flag:"dtrack-api-key"`
 	DtrackLabelTagMatcher   string   `yaml:"dtrackLabelTagMatcher" env:"SBOM_DTRACK_LABEL_TAG_MATCHER" flag:"dtrack-label-tag-matcher"`
+	DtrackCaCertFile        string   `yaml:"dtrackCaCertFile" env:"SBOM_DTRACK_CA_CERT_FILE" flag:"dtrack-ca-cert-file"`
+	DtrackClientCertFile    string   `yaml:"dtrackClientCertFile" env:"SBOM_DTRACK_CLIENT_CERT_FILE" flag:"dtrack-client-cert-file"`
+	DtrackClientKeyFile     string   `yaml:"dtrackClientKeyFile" env:"SBOM_DTRACK_CLIENT_KEY_FILE" flag:"dtrack-client-key-file"`
 	KubernetesClusterId     string   `yaml:"kubernetesClusterId" env:"SBOM_KUBERNETES_CLUSTER_ID" flag:"kubernetes-cluster-id"`
 	JobImage                string   `yaml:"jobImage" env:"SBOM_JOB_IMAGE" flag:"job-image"`
 	JobImagePullSecret      string   `yaml:"jobImagePullSecret" env:"SBOM_JOB_IMAGE_PULL_SECRET" flag:"job-image-pull-secret"`
@@ -56,6 +59,9 @@ var (
 	/* #nosec */
 	ConfigKeyDependencyTrackApiKey          = "dtrack-api-key"
 	ConfigKeyDependencyTrackLabelTagMatcher = "dtrack-label-tag-matcher"
+	ConfigKeyDependencyTrackCaCertFile      = "dtrack-ca-cert-file"
+	ConfigKeyDependencyTrackClientCertFile  = "dtrack-client-cert-file"
+	ConfigKeyDependencyTrackClientKeyFile   = "dtrack-client-key-file"
 	ConfigKeyKubernetesClusterId            = "kubernetes-cluster-id"
 	ConfigKeyJobImage                       = "job-image"
 	/* #nosec */

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -135,8 +135,11 @@ func initTargets(k8s *kubernetes.KubeClient) []target.Target {
 			baseUrl := internal.OperatorConfig.DtrackBaseUrl
 			apiKey := internal.OperatorConfig.DtrackApiKey
 			podLabelTagMatcher := internal.OperatorConfig.DtrackLabelTagMatcher
+			caCertFile := internal.OperatorConfig.DtrackCaCertFile
+			clientCertFile := internal.OperatorConfig.DtrackClientCertFile
+			clientKeyFile := internal.OperatorConfig.DtrackClientKeyFile
 			k8sClusterId := internal.OperatorConfig.KubernetesClusterId
-			t := dtrack.NewDependencyTrackTarget(baseUrl, apiKey, podLabelTagMatcher, k8sClusterId)
+			t := dtrack.NewDependencyTrackTarget(baseUrl, apiKey, podLabelTagMatcher, caCertFile, clientCertFile, clientKeyFile, k8sClusterId)
 			err = t.ValidateConfig()
 			targets = append(targets, t)
 		} else if ta == "oci" {


### PR DESCRIPTION
This PR exposes the mTLS configuration option of the dtrack-client.

It adds the following env variables/arguments:

- dtrack-ca-cert-file
- dtrack-client-cert-file
- dtrack-client-key-file