### PR TITLE
fix: flag name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ All parameters are cli-flags. The flags can be configured as args or as environm
 | `targets` | `false` | `git` | Comma-delimited list of targets to sent the generated SBOMs to. Possible targets `git`, `dtrack`, `oci`, `configmap`. Ignored with a `job-image` |
 | `pod-label-selector` | `false` | `""` | Kubernetes Label-Selector for pods. |
 | `namespace-label-selector` | `false` | `""` | Kubernetes Label-Selector for namespaces. |
-| `fallback-image-pull-secret` | `false` | `""` | Kubernetes Pull-Secret Name to load as a fallback when all others fail (must be in the same namespace as the sbom-operator) |
+| `fallback-pull-secret` | `false` | `""` | Kubernetes Pull-Secret Name to load as a fallback when all others fail (must be in the same namespace as the sbom-operator) |
 | `registry-proxy` | `false` | `[]` | Proxy-Registry-Hosts to use. Flag can be used multiple times. Value-Mapping e.g. `docker.io=ghcr.io` |
 | `delete-orphan-images` | `false` | `true` | Delete orphan images automatically |
 


### PR DESCRIPTION
Hi,

There is a small mistake in the documentation. The flag "fallback-pull-secret" has a wrong name: "fallback-image-pull-secret". Which leads to "Error: unknown flag" when copy+pasted into the flags used to run the service.

See the error here:
```
time="2024-07-09T12:00:36Z" level=info msg="spawning process: [/usr/local/bin/sbom-operator --dtrack-api-key=[...] --dtrack-base-url=[...] --fallback-image-pull-secret=[...] --format=cyclonedx --targets=dtrack --verbosity=debug]" app=vault-env
Error: unknown flag: --fallback-image-pull-secret
Usage:
  sbom-operator [flags]
[...]
Flags:
  -c, --config string                                 Path to the config-file.
 [...]
      --fallback-pull-secret string                   Fallback-Pull-Secret
[...]
```