### PR TITLE
fix: allow upload of BOMs longer than 20000000 chars to dependency-track

### DIFF
--- a/internal/target/dtrack/dtrack_target.go
+++ b/internal/target/dtrack/dtrack_target.go
@@ -143,7 +143,7 @@ func (g *DependencyTrackTarget) ProcessSbom(ctx *target.TargetContext) error {
 	logrus.Infof("Sending SBOM to Dependency Track (project=%s, version=%s)", projectName, version)
 
 	sbomBase64 := base64.StdEncoding.EncodeToString([]byte(ctx.Sbom))
-	uploadToken, err := client.BOM.Upload(
+	uploadToken, err := client.BOM.PostBom(
 		context.Background(),
 		dtrack.BOMUploadRequest{ProjectName: projectName, ProjectVersion: version, AutoCreate: true, BOM: sbomBase64},
 	)


### PR DESCRIPTION
..by using the POST endpoint that supports multipart/form-data

Hi folks,

we are using the sbom-operator to generate BOMs auf Atlassian applications like JIRA and Confluence. Our BOMs are then sent to Dependency Track.

Until recently this was working flawlessly, however since a few weeks ago the BOMs for these applications (e.g. `atlassian/jira-software:9.12.19`) have grown larger than 20000000 characters. 

This resulted in the following error from the sbom-operator:

```
sbom-operator-9c44b6c96-9rwgs sbom-operator time="2025-03-17T11:49:33Z" level=error msg="Could not upload BOM: String length (20054016) exceeds the maximum length (20000000) (through reference chain: org.dependencytrack.resources.v1.vo.BomSubmitRequest[\"bom\"]) (status: 400)"
```

I have looked into the code of DTrack and they provide two methods to upload BOMs in their client library: https://github.com/DependencyTrack/client-go/blob/v0.13.0/bom.go

- [Upload](https://github.com/DependencyTrack/client-go/blob/v0.13.0/bom.go#L85) (HTTP PUT)
- [PostBom](https://github.com/DependencyTrack/client-go/blob/v0.13.0/bom.go#L101C22-L101C29) (HTTP POST)

The `PostBom` method supports multi-part/form-data and is the recommended method when uploading BOMs as far as I can tell (see also [this issue 3182 at DTrack](https://github.com/DependencyTrack/dependency-track/issues/3182)).

To fix this, I've updated the sbom-operator to use the `PostBom` method which utilizes the same parameters as the previous `Upload` method. I've validated this by building the sbom-operator locally, pushing the image to our private registry and scanning the mentioned image again. This resulted in a successful scan:

```
time="2025-03-21T16:33:58Z" level=info msg="Processing image docker.io/atlassian/jira-software@sha256:67a776f2e6cdf28550f9802608fdeffeb34407f6a6d70bee29dd7764befffc6a"
time="2025-03-21T16:35:06Z" level=info msg="Sending SBOM to Dependency Track (project=docker.io/atlassian/jira-software, version=10.3.4)"
time="2025-03-21T16:35:06Z" level=info msg="Uploaded SBOM (upload-token=0b8f1278-b429-476b-a9ff-35c6267da370)"
```

Let me know if you have any questions or suggestions.

Best regards,
Florian.