### PR TITLE
fix(dtrack): keep projects with multiple digests from being wrongly removed on cleanup

### DIFF
--- a/internal/target/dtrack/dtrack_target.go
+++ b/internal/target/dtrack/dtrack_target.go
@@ -191,9 +191,15 @@ func (g *DependencyTrackTarget) ProcessSbom(ctx *target.TargetContext) error {
 	if !containsTag(project.Tags, sbomOperator) {
 		project.Tags = append(project.Tags, dtrack.Tag{Name: sbomOperator})
 	}
-	if !containsTag(project.Tags, rawImageId) {
-		project.Tags = append(project.Tags, dtrack.Tag{Name: fmt.Sprintf("%s=%s", rawImageId, ctx.Image.ImageID)})
-	}
+
+	// Ensure the raw-image-id tag reflects the current container digest. Previously
+	// `containsTag(project.Tags, rawImageId)` was a prefix match, so any
+	// `raw-image-id=...` tag prevented the new one from being added. When the same
+	// (projectName, version) pair was backed by different digests (mutable `:latest`,
+	// re-pushed tag, multiple pods), DT kept the first digest forever. During cleanup
+	// this caused `LoadImages()` to emit a stale digest and `Remove()` to operate on
+	// the still-live project, deleting it.
+	project.Tags = rotateRawImageIdTag(project.Tags, ctx.Image.ImageID)
 	podNamespaceTag := podNamespaceTagKey + "=" + ctx.Pod.PodNamespace
 	if !containsTag(project.Tags, podNamespaceTag) {
 		project.Tags = append(project.Tags, dtrack.Tag{Name: podNamespaceTag})
@@ -275,9 +281,13 @@ func (g *DependencyTrackTarget) LoadImages() ([]*libk8s.RegistryImage, error) {
 		return nil, err
 	}
 
-	if g.imageProjectMap == nil {
-		g.imageProjectMap = make(map[string]uuid.UUID)
-	}
+	// Always rebuild the imageProjectMap from DT state. Previously the map was
+	// only initialised when nil, so entries accumulated across reconcile cycles.
+	// After a pod/image update, stale `digest -> UUID` entries kept pointing at
+	// UUIDs of still-live projects (because rotation of raw-image-id was broken,
+	// see ProcessSbom). That caused `Remove()` to operate on live projects.
+	// Resetting here guarantees the map mirrors the current DT state.
+	g.imageProjectMap = make(map[string]uuid.UUID)
 
 	var (
 		pageNumber = 1
@@ -460,6 +470,21 @@ func removeTag(tags []dtrack.Tag, tagString string) []dtrack.Tag {
 		}
 	}
 	return newTags
+}
+
+// rotateRawImageIdTag drops any existing `raw-image-id=*` tag(s) from the slice
+// and appends a single `raw-image-id=<digest>` tag with the current digest. Used
+// to keep the project's recorded digest in sync with the container that the
+// operator just processed. See ProcessSbom for the rationale.
+func rotateRawImageIdTag(tags []dtrack.Tag, currentImageID string) []dtrack.Tag {
+	prefix := rawImageId + "="
+	out := make([]dtrack.Tag, 0, len(tags)+1)
+	for _, tag := range tags {
+		if !strings.HasPrefix(tag.Name, prefix) {
+			out = append(out, tag)
+		}
+	}
+	return append(out, dtrack.Tag{Name: prefix + currentImageID})
 }
 
 func getRepoWithVersion(image *libk8s.RegistryImage, useShortName bool, k8sClusterId string, k8sClusterIdMode string) (string, string) {

--- a/internal/target/dtrack/dtrack_target_test.go
+++ b/internal/target/dtrack/dtrack_target_test.go
@@ -3,12 +3,14 @@ package dtrack
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	dtrack "github.com/DependencyTrack/client-go"
 	libk8s_real "github.com/ckotzbauer/libk8soci/pkg/kubernetes"
 	liboci "github.com/ckotzbauer/libk8soci/pkg/oci"
 	"github.com/ckotzbauer/sbom-operator/internal/target"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -250,6 +252,118 @@ func TestRemoveMinimal(t *testing.T) {
 	}
 
 	_ = g.Remove(images)
+}
+
+// TestRawImageIdTagIsRotated ensures the raw-image-id tag is updated to reflect
+// the current container digest each time ProcessSbom runs against an existing
+// project. The previous behaviour froze the first digest forever and produced
+// false orphans during cleanup when the same (projectName, version) was backed
+// by a different digest (mutable :latest, re-pushed tag, multiple pods).
+func TestRawImageIdTagIsRotated(t *testing.T) {
+	t.Run("first digest is added", func(t *testing.T) {
+		project := dtrack.Project{Tags: []dtrack.Tag{{Name: sbomOperator}}}
+		ctx := &target.TargetContext{Image: &liboci.RegistryImage{ImageID: "alpine@sha256:aaa"}}
+
+		project.Tags = rotateRawImageIdTag(project.Tags, ctx.Image.ImageID)
+
+		assert.Len(t, project.Tags, 2)
+		assert.Equal(t, sbomOperator, project.Tags[0].Name)
+		assert.Equal(t, "raw-image-id=alpine@sha256:aaa", project.Tags[1].Name)
+	})
+
+	t.Run("existing digest is replaced, not appended", func(t *testing.T) {
+		project := dtrack.Project{Tags: []dtrack.Tag{
+			{Name: sbomOperator},
+			{Name: "raw-image-id=alpine@sha256:aaa"},
+			{Name: "kubernetes-cluster=my-cluster"},
+		}}
+
+		project.Tags = rotateRawImageIdTag(project.Tags, "alpine@sha256:bbb")
+
+		assert.Len(t, project.Tags, 3)
+		// raw-image-id replaced, other tags kept
+		var rawTags []string
+		for _, tag := range project.Tags {
+			if strings.HasPrefix(tag.Name, "raw-image-id=") {
+				rawTags = append(rawTags, tag.Name)
+			}
+		}
+		assert.Equal(t, []string{"raw-image-id=alpine@sha256:bbb"}, rawTags)
+		assert.True(t, containsTag(project.Tags, sbomOperator))
+		assert.True(t, containsTag(project.Tags, "kubernetes-cluster=my-cluster"))
+	})
+
+	t.Run("multiple stale raw-image-id tags collapsed to one", func(t *testing.T) {
+		project := dtrack.Project{Tags: []dtrack.Tag{
+			{Name: "raw-image-id=alpine@sha256:aaa"},
+			{Name: "raw-image-id=alpine@sha256:bbb"},
+			{Name: sbomOperator},
+		}}
+
+		project.Tags = rotateRawImageIdTag(project.Tags, "alpine@sha256:ccc")
+
+		var rawTags []string
+		for _, tag := range project.Tags {
+			if strings.HasPrefix(tag.Name, "raw-image-id=") {
+				rawTags = append(rawTags, tag.Name)
+			}
+		}
+		assert.Equal(t, []string{"raw-image-id=alpine@sha256:ccc"}, rawTags)
+	})
+}
+
+// TestLoadImagesResetsImageProjectMap ensures stale digest -> UUID entries do
+// not survive across LoadImages calls. Without this, a re-pulled image would
+// leave a stale entry pointing at a still-live project's UUID, and a subsequent
+// Remove() on the stale digest would operate on the live project.
+func TestLoadImagesResetsImageProjectMap(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Path == "/api/v1/project" && r.Method == "GET" {
+			// One project tagged for our cluster, current raw-image-id=alpine@sha256:new
+			_, _ = w.Write([]byte(`[{
+				"name": "alpine", "version": "3.14",
+				"uuid": "8c940608-8e62-431a-ac5d-2092b7c41372",
+				"tags": [
+					{"name": "kubernetes-cluster=my-cluster"},
+					{"name": "sbom-operator"},
+					{"name": "raw-image-id=alpine@sha256:new"}
+				]
+			}]`))
+			return
+		}
+		if r.URL.Path == "/api/v1/version" {
+			_, _ = w.Write([]byte(`{"version": "4.8.0"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"totalCount": 1}`))
+	}))
+	defer ts.Close()
+
+	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "", "", true)
+	err := g.Initialize()
+	assert.NoError(t, err)
+
+	// Seed a stale entry from a previous reconcile cycle.
+	g.imageProjectMap = map[string]uuid.UUID{
+		"alpine@sha256:OLD": uuid.MustParse("8c940608-8e62-431a-ac5d-2092b7c41372"),
+	}
+
+	images, err := g.LoadImages()
+	assert.NoError(t, err)
+
+	// Returned set reflects the current DT state only.
+	assert.Len(t, images, 1)
+	assert.Equal(t, "alpine@sha256:new", images[0].ImageID)
+
+	// The stale entry must be gone; only the current digest remains.
+	_, staleStillPresent := g.imageProjectMap["alpine@sha256:OLD"]
+	assert.False(t, staleStillPresent, "stale digest entry must be cleared on LoadImages")
+
+	currentUUID, currentPresent := g.imageProjectMap["alpine@sha256:new"]
+	assert.True(t, currentPresent)
+	assert.Equal(t, "8c940608-8e62-431a-ac5d-2092b7c41372", currentUUID.String())
 }
 
 func TestLoadImagesTagMode(t *testing.T) {


### PR DESCRIPTION
Fixes #889.

Two changes in `internal/target/dtrack/dtrack_target.go`:

1. `ProcessSbom` now calls a new `rotateRawImageIdTag()` helper instead of the `containsTag` prefix check. The helper drops any existing `raw-image-id=*` tag and appends one with the current digest, so the tag tracks the latest processed container.

2. `LoadImages()` rebuilds `imageProjectMap` unconditionally on every call. Previously it only initialised when nil, so stale `digest -> UUID` entries carried over between reconcile cycles.

### Tests

- `TestRawImageIdTagIsRotated` — first digest added; existing replaced (other tags preserved); multiple stale `raw-image-id` tags collapsed to one.
- `TestLoadImagesResetsImageProjectMap` — stale digest is gone after `LoadImages()`, current one is present.

All tests in `internal/target/dtrack/...` pass.

### Scope

`dtrack` target only. Other targets, processor, RBAC, config — untouched. `containsTag`'s prefix behaviour is left as-is because other callers compare against full-string tags and are not affected.

### Verified end-to-end

Reproduced the bug on v0.41.5 against a real Dependency-Track 4.13 + EKS setup, applied the patch, re-ran: no false removals. Verified across single pod, rolling update, sidecar, multi-version same image (the repro case), init container, scale-to-zero, deployment delete, namespace label removal.
