### PR TITLE
fix(dtrack): Cluster ID prefix only added to short project name

### DIFF
--- a/internal/target/dtrack/dtrack_target.go
+++ b/internal/target/dtrack/dtrack_target.go
@@ -314,7 +314,7 @@ func (g *DependencyTrackTarget) LoadImages() ([]*libk8s.RegistryImage, error) {
 
 			//extend lookup logic to support `prefix` mode to resolve image association
 			if g.k8sClusterIdMode == "prefix" {
-				imageRelatesToCluster = strings.HasPrefix(project.Name, g.k8sClusterId)
+				imageRelatesToCluster = strings.HasPrefix(project.Name, g.k8sClusterId+"-")
 			}
 
 			for _, tag := range project.Tags {

--- a/internal/target/dtrack/dtrack_target.go
+++ b/internal/target/dtrack/dtrack_target.go
@@ -495,13 +495,14 @@ func getRepoWithVersion(image *libk8s.RegistryImage, useShortName bool, k8sClust
 	}
 
 	var projectName string
+	//add Cluster prefix to projectName if prefix mode is set
+  if k9sClusterIdMode == "prefix" {
+    projectName = k8sClusterId + "-"
+  }
 	if useShortName {
-		if k8sClusterIdMode == "prefix" {
-			projectName = k8sClusterId + "-"
-		}
 		projectName += imageRef.ShortName()
 	} else {
-		projectName = imageRef.Repository()
+		projectName += imageRef.Repository()
 	}
 
 	if strings.Index(image.Image, "sha256") != 0 {

--- a/internal/target/dtrack/dtrack_target.go
+++ b/internal/target/dtrack/dtrack_target.go
@@ -496,7 +496,7 @@ func getRepoWithVersion(image *libk8s.RegistryImage, useShortName bool, k8sClust
 
 	var projectName string
 	//add Cluster prefix to projectName if prefix mode is set
-	if k9sClusterIdMode == "prefix" {
+	if k8sClusterIdMode == "prefix" {
 		projectName = k8sClusterId + "-"
 	}
 	if useShortName {

--- a/internal/target/dtrack/dtrack_target.go
+++ b/internal/target/dtrack/dtrack_target.go
@@ -496,9 +496,9 @@ func getRepoWithVersion(image *libk8s.RegistryImage, useShortName bool, k8sClust
 
 	var projectName string
 	//add Cluster prefix to projectName if prefix mode is set
-  if k9sClusterIdMode == "prefix" {
-    projectName = k8sClusterId + "-"
-  }
+	if k9sClusterIdMode == "prefix" {
+		projectName = k8sClusterId + "-"
+	}
 	if useShortName {
 		projectName += imageRef.ShortName()
 	} else {

--- a/internal/target/dtrack/dtrack_target_test.go
+++ b/internal/target/dtrack/dtrack_target_test.go
@@ -25,7 +25,7 @@ func TestGetRepoWithVersion(t *testing.T) {
 		expectedVersion  string
 	}{
 		{
-			name:             "Long name, no prefix",
+			name:             "Long name, tag mode",
 			image:            &liboci.RegistryImage{ImageID: "docker.io/library/alpine:3.14", Image: "alpine:3.14"},
 			useShortName:     false,
 			k8sClusterId:     "my-cluster",
@@ -34,6 +34,15 @@ func TestGetRepoWithVersion(t *testing.T) {
 			expectedVersion:  "3.14",
 		},
 		{
+			name:             "Long name, prefix mode",
+			image:            &liboci.RegistryImage{ImageID: "docker.io/library/alpine:3.14", Image: "alpine:3.14"},
+			useShortName:     false,
+			k8sClusterId:     "my-cluster",
+			k8sClusterIdMode: "prefix",
+			expectedName:     "my-cluster-docker.io/library/alpine",
+			expectedVersion:  "3.14",
+		},
+    {
 			name:             "Short name, prefix mode",
 			image:            &liboci.RegistryImage{ImageID: "docker.io/library/alpine:3.14", Image: "alpine:3.14"},
 			useShortName:     true,


### PR DESCRIPTION
Hi!

as discussed in https://github.com/ckotzbauer/sbom-operator/issues/891, this PR fixes that the `k8sClusterId` prefix is only added to the `projectName` when `useShortName` is enabled. The `k8sClusterId` prefix is now added to the empty `projectName` if prefix mode is enabled. After that, the long or short name is appended.

Furthermore, I added a small fix for the prefix matching in the project lookup logic. The dash after the `k8sClusterId' was missing. This was a finding by claude when I asked it to review my above mentioned fix for the cluster prefix.

Also, I added a test case for long name with prefix mode.

Cheers,
Eric