### PR TITLE
fix: warn on incompatible dtrack SBOM version

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ Each image in the cluster is created as project with the full-image name (regist
 When there's no image-tag, but a digest, the digest is used as project-version.
 The `autoCreate` option of DT is used. You have to set the `--format` flag to `cyclonedx` with this target.
 
+> [!IMPORTANT]
+> Dependency-Track 5.0.x rejects CycloneDX 1.7, which is the default emitted by the Syft version currently bundled with sbom-operator. Configure `--format-version=1.6` (or `SBOM_FORMAT_VERSION=1.6` / `formatVersion: "1.6"`) when using the `dtrack` target. If the version is omitted, the operator logs a startup warning but preserves Syft's default.
+
 ---
 #### Custom dtrack project name:
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/ckotzbauer/libstandard"
@@ -34,6 +35,7 @@ func newRootCmd() *cobra.Command {
 			if err := libstandard.DefaultInitializer(internal.OperatorConfig, cmd, "sbom-operator"); err != nil {
 				return err
 			}
+			warnAboutDtrackCycloneDXDefault(internal.OperatorConfig)
 			// Resolve format-version through the single unified entry point.
 			// Both daemon and informer paths receive the same resolved value.
 			fv := syft.ResolveFormatVersionWithFamily(
@@ -127,6 +129,33 @@ func newRootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().String(internal.ConfigKeyFormatVersion, "", syft.FormatVersionHelp())
 
 	return rootCmd
+}
+
+func warnAboutDtrackCycloneDXDefault(config *internal.Config) {
+	if strings.TrimSpace(config.FormatVersion) != "" {
+		return
+	}
+
+	usesDtrack := false
+	for _, configuredTarget := range config.Targets {
+		if configuredTarget == "dtrack" {
+			usesDtrack = true
+			break
+		}
+	}
+	if !usesDtrack {
+		return
+	}
+
+	formatVersion := syft.ResolveCycloneDXFormatVersion(config.Format)
+	if formatVersion.Family == "" {
+		return
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"sbom_family":  formatVersion.Family,
+		"sbom_version": formatVersion.Version,
+	}).Warn("Dependency-Track releases through 5.0.x reject the bundled default CycloneDX version; set --format-version=1.6")
 }
 
 func printVersion() {

--- a/main_test.go
+++ b/main_test.go
@@ -3,13 +3,91 @@ package main
 import (
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/ckotzbauer/sbom-operator/internal"
 	"github.com/ckotzbauer/sbom-operator/internal/syft"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDtrackDefaultCycloneDXStartupWarning(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantWarn bool
+	}{
+		{
+			name:     "Dependency-Track with default CycloneDX XML",
+			args:     []string{"--targets", "dtrack", "--format", "cyclonedx"},
+			wantWarn: true,
+		},
+		{
+			name:     "Dependency-Track among multiple targets",
+			args:     []string{"--targets", "git,dtrack", "--format", "cyclonedxjson"},
+			wantWarn: true,
+		},
+		{
+			name:     "explicit compatible version",
+			args:     []string{"--targets", "dtrack", "--format", "cyclonedx", "--format-version", "1.6"},
+			wantWarn: false,
+		},
+		{
+			name:     "non-CycloneDX format",
+			args:     []string{"--targets", "dtrack", "--format", "json"},
+			wantWarn: false,
+		},
+		{
+			name:     "non-Dependency-Track target",
+			args:     []string{"--targets", "git", "--format", "cyclonedx"},
+			wantWarn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entries := executeStartupAndCollectLogs(t, tt.args)
+			warning := findDtrackVersionWarning(entries)
+			if tt.wantWarn {
+				require.NotNil(t, warning)
+				assert.Equal(t, "1.7", warning.Data["sbom_version"])
+			} else {
+				assert.Nil(t, warning)
+			}
+		})
+	}
+}
+
+func executeStartupAndCollectLogs(t *testing.T, args []string) []*logrus.Entry {
+	t.Helper()
+
+	cmd := newRootCmd()
+	cmd.SetArgs(args)
+	cmd.Run = func(cmd *cobra.Command, args []string) {}
+
+	logger := logrus.StandardLogger()
+	previousHooks := logger.ReplaceHooks(make(logrus.LevelHooks))
+	t.Cleanup(func() {
+		logger.ReplaceHooks(previousHooks)
+	})
+	hook := logrustest.NewGlobal()
+
+	require.NoError(t, cmd.Execute())
+	return hook.AllEntries()
+}
+
+func findDtrackVersionWarning(entries []*logrus.Entry) *logrus.Entry {
+	for _, entry := range entries {
+		if strings.Contains(entry.Message, "--format-version=1.6") {
+			return entry
+		}
+	}
+	return nil
+}
 
 // TestValidateFormatVersion_StartupBoundary verifies that the startup
 // boundary (PersistentPreRunE) rejects invalid CycloneDX versions before
@@ -381,6 +459,11 @@ func TestREADMEFormatVersionDocumentation(t *testing.T) {
 	assert.Contains(t, readme, "sbom-operator --format=cyclonedxjson --format-version=1.3")
 	assert.Contains(t, readme, "export SBOM_FORMAT_VERSION=2.3")
 	assert.Contains(t, readme, "custom-format")
+
+	// 1f. Dependency-Track 5.0.x users are directed to the compatible
+	// CycloneDX version without changing the global Syft default.
+	assert.Contains(t, readme, "Dependency-Track 5.0.x rejects CycloneDX 1.7")
+	assert.Contains(t, readme, "`--format-version=1.6`")
 }
 
 func TestFormatVersionFlagHelpUsesSyftMetadata(t *testing.T) {


### PR DESCRIPTION
## Summary

- warn at startup when the `dtrack` target uses the bundled default CycloneDX version that Dependency-Track 5.0.x rejects
- keep the Syft default unchanged and stay quiet for explicit versions, non-CycloneDX formats, and non-Dependency-Track targets
- document the compatible `--format-version=1.6` flag, environment variable, and YAML setting

Fixes #972

## Validation

- `go test . -count=1`
- `go test ./internal/syft -skip '^TestSyft$' -count=1`
- `go test ./internal/target/dtrack -count=1`
- `go vet ./...`
- `make lint` (0 issues)
- `make lintsec` (0 issues)

`go test ./... -count=1` was also attempted. Its live-registry `TestSyft` exceeded the repository-wide 10-minute timeout while downloading/scanning fixture images, and the pre-existing OCI test could not find `internal/target/oci/fixtures/sbom.json`. The affected startup, format-version, and Dependency-Track packages pass independently.