### PR TITLE
feat(target/dtrack): make version optional in parent project annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The value for a custom project name in dtrack by annotation at the specific Pod 
 #### Setting parent project at Dependency Track automatically:
 
 The key at kubernetes has to be suffixed with the container name the parent project is for. e.g. `my.parent.project/my-nginx`.
-The value for the parent project annotation at the specific Pod is written in the format of `project:version` or just `project` where version defaults to `latest`. E.g. `MyParentProject` or `MyParentProject:1.0`
+The value for the parent project annotation at the specific Pod is written in the format of `project:version` or just `project`. The version is optional: collection projects (parents that only aggregate children) usually do not carry a version, so a bare name like `MyParentProject` is sufficient. If a version is provided, e.g. `MyParentProject:1.0`, the parent project is matched by name and version.
 
 > [!IMPORTANT]
 > The suffix regarding container name must not be added to the config value and must not include `/`. e.g. `my.parent.project`

--- a/internal/target/dtrack/dtrack_target.go
+++ b/internal/target/dtrack/dtrack_target.go
@@ -233,13 +233,38 @@ func (g *DependencyTrackTarget) ProcessSbom(ctx *target.TargetContext) error {
 						// correct container found?
 						if containerName == ctx.Container.Name {
 							parentProjectName, parentProjectVersion := getNameAndVersionFromString(podAnnotationValue, ":")
+							hasExplicitVersion := strings.Contains(podAnnotationValue, ":")
 							logrus.Debugf("Try to find parent project by name from annotation \"%s\", for container %s, parentProjectName \"%s\" and parentProjectVersion \"%s\"", podAnnotationKey, containerName, parentProjectName, parentProjectVersion)
-							parentProject, err := client.Project.Lookup(context.Background(), parentProjectName, parentProjectVersion)
+							parentProjects, err := client.Project.GetProjectsForName(context.Background(), parentProjectName, false, true)
 							if err != nil {
 								logrus.WithError(err).Errorf(`Could not find parent project "%s"`, parentProjectName)
+							} else if len(parentProjects) == 0 {
+								logrus.Errorf(`No parent project found with name "%s"`, parentProjectName)
 							} else {
-								logrus.Infof(`Found parent project with name "%s:%s" and UUID "%s" for container "%s": %+v\n`, parentProjectName, parentProjectVersion, parentProject.UUID, containerName, parentProject)
-								project.ParentRef = &dtrack.ParentRef{UUID: parentProject.UUID}
+								var parentProject dtrack.Project
+								found := false
+								if hasExplicitVersion {
+									for _, p := range parentProjects {
+										if p.Version == parentProjectVersion {
+											parentProject = p
+											found = true
+											break
+										}
+									}
+									if !found {
+										logrus.Errorf(`No parent project found with name "%s" and version "%s"`, parentProjectName, parentProjectVersion)
+									}
+								} else {
+									if len(parentProjects) > 1 {
+										logrus.Warnf(`Multiple root projects found with name "%s", using the first one`, parentProjectName)
+									}
+									parentProject = parentProjects[0]
+									found = true
+								}
+								if found {
+									logrus.Infof(`Found parent project with name "%s" and UUID "%s" for container "%s"`, parentProjectName, parentProject.UUID, containerName)
+									project.ParentRef = &dtrack.ParentRef{UUID: parentProject.UUID}
+								}
 							}
 							break
 						}

--- a/internal/target/dtrack/dtrack_target_test.go
+++ b/internal/target/dtrack/dtrack_target_test.go
@@ -241,11 +241,6 @@ func TestProcessSbomMinimal(t *testing.T) {
 	_ = g.ProcessSbom(ctx)
 }
 
-// TestProcessSbomParentProject verifies the parent project lookup no longer
-// requires a version in the pod annotation. The operator queries
-// `GET /api/v1/project?name=XXX&onlyRoot=true` (GetProjectsForName) instead of
-// `GET /api/v1/project/lookup` so collection projects without a version can be
-// used as parents. See issue #979.
 func TestProcessSbomParentProject(t *testing.T) {
 	parentUUID := "aaaaaaaa-1111-2222-3333-444444444444"
 

--- a/internal/target/dtrack/dtrack_target_test.go
+++ b/internal/target/dtrack/dtrack_target_test.go
@@ -1,6 +1,7 @@
 package dtrack
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -238,6 +239,94 @@ func TestProcessSbomMinimal(t *testing.T) {
 	}
 
 	_ = g.ProcessSbom(ctx)
+}
+
+// TestProcessSbomParentProject verifies the parent project lookup no longer
+// requires a version in the pod annotation. The operator queries
+// `GET /api/v1/project?name=XXX&onlyRoot=true` (GetProjectsForName) instead of
+// `GET /api/v1/project/lookup` so collection projects without a version can be
+// used as parents. See issue #979.
+func TestProcessSbomParentProject(t *testing.T) {
+	parentUUID := "aaaaaaaa-1111-2222-3333-444444444444"
+
+	tests := []struct {
+		name            string
+		annotationValue string
+		parentProjects  string
+		expectParentRef bool
+	}{
+		{
+			name:            "parent project by name only (no version)",
+			annotationValue: "MyParentProject",
+			parentProjects:  `[{"name":"MyParentProject","version":"","uuid":"` + parentUUID + `"}]`,
+			expectParentRef: true,
+		},
+		{
+			name:            "parent project by name and version",
+			annotationValue: "MyParentProject:1.0",
+			parentProjects:  `[{"name":"MyParentProject","version":"1.0","uuid":"` + parentUUID + `"}]`,
+			expectParentRef: true,
+		},
+		{
+			name:            "explicit version does not match any returned project",
+			annotationValue: "MyParentProject:2.0",
+			parentProjects:  `[{"name":"MyParentProject","version":"1.0","uuid":"` + parentUUID + `"}]`,
+			expectParentRef: false,
+		},
+		{
+			name:            "no parent project found",
+			annotationValue: "MyParentProject",
+			parentProjects:  `[]`,
+			expectParentRef: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updateBody := ""
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				switch {
+				case r.URL.Path == "/api/v1/bom":
+					_, _ = w.Write([]byte(`{"token": "uuid-token"}`))
+				case r.URL.Path == "/api/v1/project/lookup":
+					_, _ = w.Write([]byte(`{"name":"alpine","version":"3.14","uuid":"8c940608-8e62-431a-ac5d-2092b7c41372"}`))
+				case r.URL.Path == "/api/v1/project" && r.Method == http.MethodGet:
+					// GetProjectsForName for parent lookup
+					_, _ = w.Write([]byte(tt.parentProjects))
+				default:
+					// Project.Update - capture the body to inspect ParentRef
+					buf, _ := io.ReadAll(r.Body)
+					updateBody = string(buf)
+					_, _ = w.Write([]byte(`{}`))
+				}
+			}))
+			defer ts.Close()
+
+			g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "my.parent.project", "", true)
+			err := g.Initialize()
+			assert.NoError(t, err)
+			// Pre-populate so LoadImages is skipped during ProcessSbom.
+			g.imageProjectMap = map[string]uuid.UUID{}
+
+			ctx := &target.TargetContext{
+				Image:     &liboci.RegistryImage{ImageID: "alpine:3.14", Image: "alpine:3.14"},
+				Pod:       &libk8s_real.PodInfo{PodNamespace: "default", Annotations: map[string]string{"my.parent.project/alpine": tt.annotationValue}},
+				Container: &libk8s_real.ContainerInfo{Name: "alpine"},
+				Sbom:      "{}",
+			}
+
+			err = g.ProcessSbom(ctx)
+			assert.NoError(t, err)
+
+			if tt.expectParentRef {
+				assert.Contains(t, updateBody, parentUUID)
+			} else {
+				assert.NotContains(t, updateBody, parentUUID)
+			}
+		})
+	}
 }
 
 func TestRemoveMinimal(t *testing.T) {


### PR DESCRIPTION
## Summary

Let [Dependency Track collection projects](https://dependencytrack.github.io/docs/next/concepts/projects/#collection-projects) without a version be used as parents when reporting SBOM to Dependency Track.

## Changes

- `internal/target/dtrack/dtrack_target.go` — Parent project lookup migrated from `client.Project.Lookup(name, version)` (`GET /v1/project/lookup`, requires a version) to `client.Project.GetProjectsForName(name, false, true)` (`GET /v1/project?name=…&onlyRoot=true`, no version required):
  - no version in annotation → uses the first matching root project (warns if several share the name)
  - version specified and found → matches by name + version
  - version specified but not found → logs an error and skips setting the parent ref (strict matching), avoiding silent links to the wrong parent version

- `internal/target/dtrack/dtrack_target_test.go` — Added `TestProcessSbomParentProject` with 4 subtests (name-only, name+version, version-mismatch-skip, not-found) + fixed the parent UUID to be distinct from the main project

- `README.md` — Documented that the parent-project annotation version is now optional.

---

Closes #979 

_Contribution made with the help of OpenCode._