### PR TITLE
feat(target/dtrack): manage project's active/isLatest state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ sbom-git-operator/
 │       │   ├── git_target.go        # Git target: stores SBOMs as files in a git repository
 │       │   └── git_target_test.go   # Tests for ImageIDToFilePath
 │       ├── dtrack/
-│       │   └── dtrack_target.go     # Dependency Track target: uploads BOMs via API, manages project tags
+│       │   └── dtrack_target.go     # Dependency Track target: uploads BOMs, manages project tags, project active/inactive lifecycle
 │       ├── oci/
 │       │   ├── oci_target.go        # OCI registry target: pushes SBOMs as OCI artifacts
 │       │   ├── oci.go               # OCI image/layer construction, media type mapping
@@ -106,6 +106,18 @@ type Target interface {
 ```
 
 Four implementations: `git`, `dtrack`, `oci`, `configmap`. Selected via `--targets` flag (comma-separated list).
+
+An optional extension interface `DeactivateTarget` is implemented by the dtrack target:
+
+```go
+type DeactivateTarget interface {
+    Target
+    Deactivate(images []*oci.RegistryImage) error
+    ShouldDeactivateOrphans() bool
+}
+```
+
+When `ShouldDeactivateOrphans()` returns true, the processor calls `Deactivate()` (rather than `Remove()`) for orphaned images, regardless of the global `--delete-orphan-images` flag. Other targets do not implement it and fall back to `Remove()`.
 
 ### Job Image Mode
 
@@ -202,12 +214,13 @@ The `hack/run-tests.sh` script:
 
 ### Test Files
 
-| Test file                                | What it tests                                                                                                                                              |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `internal/kubernetes/image_test.go`      | Registry proxy mapping (`ApplyProxyRegistry`)                                                                                                              |
-| `internal/syft/syft_test.go`             | End-to-end SBOM generation against real images (alpine, redis, node, fedora) in JSON, CycloneDX XML, SPDX JSON formats. Uses fixture files for comparison. |
-| `internal/target/git/git_target_test.go` | `ImageIDToFilePath` conversion logic                                                                                                                       |
-| `internal/target/oci/oci_target_test.go` | OCI target integration test (requires `TEST_DIGEST` and `DATE` env vars)                                                                                   |
+| Test file                                      | What it tests                                                                                                                                              |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `internal/kubernetes/image_test.go`            | Registry proxy mapping (`ApplyProxyRegistry`)                                                                                                              |
+| `internal/syft/syft_test.go`                   | End-to-end SBOM generation against real images (alpine, redis, node, fedora) in JSON, CycloneDX XML, SPDX JSON formats. Uses fixture files for comparison. |
+| `internal/target/git/git_target_test.go`       | `ImageIDToFilePath` conversion logic                                                                                                                       |
+| `internal/target/oci/oci_target_test.go`       | OCI target integration test (requires `TEST_DIGEST` and `DATE` env vars)                                                                                   |
+| `internal/target/dtrack/dtrack_target_test.go` | Project active/inactive lifecycle, sibling deactivation, orphan deactivation, LoadImages inactive filter, reactivation without re-upload                   |
 
 ### SBOM Format Test Coverage
 
@@ -311,6 +324,7 @@ kubectl apply -f deploy/job-image/
 - **SBOM file naming**: Files are named `sbom.json`, `sbom.xml`, `sbom.spdx`, or `sbom.txt` depending on format (see `syft.GetFileName()`).
 - **Git path structure**: Image IDs are converted to file paths by replacing `@` with `/` and `:` with `_` (e.g., `alpine@sha256:abc...` becomes `alpine/sha256_abc.../sbom.json`).
 - **Dependency Track tags**: Projects are tagged with `kubernetes-cluster=<id>`, `sbom-operator`, `raw-image-id=<id>`, and `namespace=<ns>`. Multi-cluster awareness is built in -- cluster tags are managed per cluster ID.
+- **Dependency Track project lifecycle management**: When `--dtrack-manage-project-active-status` is enabled, the dtrack target manages project active/isLatest state. On SBOM processing, the running version is set `Active=true, IsLatest=true` and sibling versions under the same parent are deactivated. Orphaned projects are deactivated (not deleted) via the optional `DeactivateTarget` interface, preserving version history. `--delete-orphan-images` is bypassed for dtrack when active. A parent project (via `--dtrack-parent-project-annotation-key` or `--dtrack-default-parent-project`) is required. On rollback to a previously deployed image with a matching digest, an inactive project is reactivated without re-uploading the BOM. Requires DT v4.12.0+ for `isLatest`.
 - **Security context**: The container runs as non-root (UID 101), read-only root filesystem, all capabilities dropped, seccomp RuntimeDefault profile.
 - **Health endpoint**: `GET :8080/health` returns 200 with body "Running!".
 - **Scratch-based image**: Final container image is built FROM scratch with only the static binary, CA certs, and timezone data.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ not present in the cluster anymore are removed from the configured targets (exce
 | `dtrack-kubernetes-cluster-id-mode`| `false`| `"tag"` | Mode for using the kubernetes-cluster-id. Options: tag (adds cluster ID as a project tag) or prefix (prefixes the project name with the cluster ID). |
 | `dtrack-parent-project-annotation-key` | `false` | `""` | Kubernetes pod annotation key to set parent project automatically, e.g. "my.pod.annotation" |
 | `dtrack-project-name-annotation-key` | `false` | `""` | Kubernetes pod annotation key to set custom dtrack project name automatically, e.g. "my.pod.annotation" |
+| `dtrack-manage-project-active-status` | `true` when enabled without parent config | `false` | Manage project active/isLatest status based on running pods. Orphans are deactivated instead of deleted. Requires a parent project. |
 | `kubernetes-cluster-id` | `false` | `"default"` | Kubernetes Cluster ID (to be used in Dependency-Track or Job-Images) |
 
 Each image in the cluster is created as project with the full-image name (registry and image-path without tag) and the image-tag as project-version.
@@ -225,6 +226,21 @@ The value for the parent project annotation at the specific Pod is written in th
 
 > [!IMPORTANT]
 > The suffix regarding container name must not be added to the config value and must not include `/`. e.g. `my.parent.project`
+
+---
+
+#### Project active/inactive lifecycle management
+
+When `--dtrack-manage-project-active-status` is enabled, the operator manages project active/isLatest state in Dependency Track:
+
+- **Running version**: set `Active=true, IsLatest=true`
+- **Sibling versions** under the same parent (matched by project name): set `Active=false, IsLatest=false`
+- **Orphaned projects** (no longer running in any cluster): deactivated instead of deleted, preserving version history. The global `--delete-orphan-images` flag is bypassed for dtrack when this is active.
+- **Rollback**: when a pod rolls back to a previously deployed image with a matching digest, the inactive project is reactivated without re-uploading the BOM.
+
+A parent project is required — either `--dtrack-parent-project-annotation-key` or `--dtrack-default-parent-project`. In multi-cluster tag mode, the current cluster's tag is removed first and the project is only deactivated if no other clusters are still using it.
+
+Requires Dependency Track v4.12.0+ for the `isLatest` field.
 
 ---
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	DtrackParentProjectAnnotationKey string   `yaml:"dtrackParentProjectAnnotationKey" env:"SBOM_DTRACK_PARENT_PROJECT_ANNOTATION_KEY" flag:"dtrack-parent-project-annotation-key"`
 	DtrackProjectNameAnnotationKey   string   `yaml:"dtrackProjectNameAnnotationKey" env:"SBOM_DTRACK_PROJECT_NAME_ANNOTATION_KEY" flag:"dtrack-project-name-annotation-key"`
 	DtrackUseShortName               bool     `yaml:"dtrackUseShortName" env:"SBOM_DTRACK_USE_SHORT_NAME" flag:"dtrack-use-short-name"`
+	DtrackManageProjectActiveStatus  bool     `yaml:"dtrackManageProjectActiveStatus" env:"SBOM_DTRACK_MANAGE_PROJECT_ACTIVE_STATUS" flag:"dtrack-manage-project-active-status"`
 	DtrackKubernetesClusterIdMode    string   `yaml:"dtrackKubernetesClusterIdMode" env:"SBOM_DTRACK_KUBERNETES_CLUSTER_ID_MODE" flag:"dtrack-kubernetes-cluster-id-mode"`
 	KubernetesClusterId              string   `yaml:"kubernetesClusterId" env:"SBOM_KUBERNETES_CLUSTER_ID" flag:"kubernetes-cluster-id"`
 	JobImage                         string   `yaml:"jobImage" env:"SBOM_JOB_IMAGE" flag:"job-image"`
@@ -75,6 +76,7 @@ var (
 	ConfigKeyDependencyTrackDtrackParentProjectAnnotationKey = "dtrack-parent-project-annotation-key"
 	ConfigKeyDependencyTrackDtrackProjectNameAnnotationKey   = "dtrack-project-name-annotation-key"
 	ConfigKeyDependencyTrackUseShortName                     = "dtrack-use-short-name"
+	ConfigKeyDependencyTrackManageProjectActiveStatus        = "dtrack-manage-project-active-status"
 	ConfigKeyKubernetesClusterId                             = "kubernetes-cluster-id"
 	ConfigKeyJobImage                                        = "job-image"
 	/* #nosec */

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -261,7 +261,8 @@ func initTargets(k8s *kubernetes.KubeClient) []target.Target {
 			k8sClusterIdMode := internal.OperatorConfig.DtrackKubernetesClusterIdMode
 			defaultParentProject := internal.OperatorConfig.DtrackDefaultParentProject
 			useShortName := internal.OperatorConfig.DtrackUseShortName
-			t := dtrack.NewDependencyTrackTarget(baseUrl, apiKey, podLabelTagMatcher, caCertFile, clientCertFile, clientKeyFile, k8sClusterId, k8sClusterIdMode, defaultParentProject, parentProjectAnnotationKey, projectNameAnnotationKey, useShortName)
+			manageProjectActiveStatus := internal.OperatorConfig.DtrackManageProjectActiveStatus
+			t := dtrack.NewDependencyTrackTarget(baseUrl, apiKey, podLabelTagMatcher, caCertFile, clientCertFile, clientKeyFile, k8sClusterId, k8sClusterIdMode, defaultParentProject, parentProjectAnnotationKey, projectNameAnnotationKey, useShortName, manageProjectActiveStatus)
 			err = t.ValidateConfig()
 			targets = append(targets, t)
 		} else if ta == "oci" {
@@ -317,11 +318,8 @@ func (p *Processor) executeSyftScans(pods []libk8s.PodInfo, allImages []*liboci.
 			}
 		}
 
-		if len(removableImages) > 0 && internal.OperatorConfig.DeleteOrphanImages {
-			err := t.Remove(removableImages)
-			if err != nil {
-				logrus.WithError(err).Error("Failed to remove images from target")
-			}
+		if len(removableImages) > 0 {
+			p.handleOrphanImages(t, removableImages)
 		}
 	}
 }
@@ -422,12 +420,26 @@ func (p *Processor) cleanupImagesIfNeeded(removedContainers []*libk8s.ContainerI
 
 	if len(images) > 0 {
 		for _, t := range p.Targets {
-			if internal.OperatorConfig.DeleteOrphanImages {
-				err := t.Remove(images)
-				if err != nil {
-					logrus.WithError(err).Error("Failed to remove images from target")
-				}
-			}
+			p.handleOrphanImages(t, images)
+		}
+	}
+}
+
+// handleOrphanImages dispatches orphan cleanup for a single target. Targets that
+// implement DeactivateTarget and opt in via ShouldDeactivateOrphans have their
+// orphans deactivated (rather than deleted) regardless of the global
+// delete-orphan-images flag. All other targets follow delete-orphan-images.
+func (p *Processor) handleOrphanImages(t target.Target, images []*liboci.RegistryImage) {
+	if dt, ok := t.(target.DeactivateTarget); ok && dt.ShouldDeactivateOrphans() {
+		if err := dt.Deactivate(images); err != nil {
+			logrus.WithError(err).Error("Failed to deactivate images in target")
+		}
+		return
+	}
+
+	if internal.OperatorConfig.DeleteOrphanImages {
+		if err := t.Remove(images); err != nil {
+			logrus.WithError(err).Error("Failed to remove images from target")
 		}
 	}
 }

--- a/internal/target/dtrack/dtrack_target.go
+++ b/internal/target/dtrack/dtrack_target.go
@@ -544,6 +544,10 @@ func (g *DependencyTrackTarget) Deactivate(images []*libk8s.RegistryImage) error
 			}
 		}
 
+		if !project.Active {
+			continue
+		}
+
 		logrus.Infof("Image not running in any cluster - deactivating %v:%v", project.Name, project.Version)
 		_, err = client.Project.Patch(context.Background(), project.UUID, dtrack.Project{
 			Active:   false,
@@ -586,6 +590,9 @@ func (g *DependencyTrackTarget) deactivateSiblingVersions(client *dtrack.Client,
 			continue
 		}
 		if !containsTag(sibling.Tags, sbomOperator) {
+			continue
+		}
+		if !sibling.Active {
 			continue
 		}
 

--- a/internal/target/dtrack/dtrack_target.go
+++ b/internal/target/dtrack/dtrack_target.go
@@ -31,6 +31,7 @@ type DependencyTrackTarget struct {
 	k8sClusterId               string
 	k8sClusterIdMode           string
 	useShortName               bool
+	manageProjectActiveStatus  bool
 	imageProjectMap            map[string]uuid.UUID
 
 	defaultParentProjectParsed *uuid.UUID
@@ -43,7 +44,7 @@ const (
 	podNamespaceTagKey = "namespace"
 )
 
-func NewDependencyTrackTarget(baseUrl, apiKey, podLabelTagMatcher, caCertFile, clientCertFile, clientKeyFile, k8sClusterId string, k8sClusterIdMode string, defaultParentProject string, parentProjectAnnotationKey string, projectNameAnnotationKey string, useShortName bool) *DependencyTrackTarget {
+func NewDependencyTrackTarget(baseUrl, apiKey, podLabelTagMatcher, caCertFile, clientCertFile, clientKeyFile, k8sClusterId string, k8sClusterIdMode string, defaultParentProject string, parentProjectAnnotationKey string, projectNameAnnotationKey string, useShortName bool, manageProjectActiveStatus bool) *DependencyTrackTarget {
 	return &DependencyTrackTarget{
 		baseUrl:                    baseUrl,
 		apiKey:                     apiKey,
@@ -57,6 +58,7 @@ func NewDependencyTrackTarget(baseUrl, apiKey, podLabelTagMatcher, caCertFile, c
 		parentProjectAnnotationKey: parentProjectAnnotationKey,
 		projectNameAnnotationKey:   projectNameAnnotationKey,
 		useShortName:               useShortName,
+		manageProjectActiveStatus:  manageProjectActiveStatus,
 	}
 }
 
@@ -94,6 +96,15 @@ func (g *DependencyTrackTarget) ValidateConfig() error {
 		g.defaultParentProjectParsed = &uuid
 	} else {
 		g.defaultParentProjectParsed = nil
+	}
+
+	if g.manageProjectActiveStatus && g.parentProjectAnnotationKey == "" && g.defaultParentProjectParsed == nil {
+		return fmt.Errorf(
+			"%s is enabled but no parent project is configured (set %s or %s)",
+			internal.ConfigKeyDependencyTrackManageProjectActiveStatus,
+			internal.ConfigKeyDependencyTrackDtrackParentProjectAnnotationKey,
+			internal.ConfigKeyDefaultParentProject,
+		)
 	}
 
 	return nil
@@ -158,23 +169,38 @@ func (g *DependencyTrackTarget) ProcessSbom(ctx *target.TargetContext) error {
 		return err
 	}
 
-	logrus.Infof("Sending SBOM to Dependency Track (project=%s, version=%s)", projectName, version)
-
-	uploadToken, err := client.BOM.PostBom(
-		context.Background(),
-		dtrack.BOMUploadRequest{ProjectName: projectName, ProjectVersion: version, AutoCreate: true, BOM: ctx.Sbom},
-	)
-	if err != nil {
-		logrus.Errorf("Could not upload BOM: %v", err)
-		return err
+	// When active-status management is enabled, try to reactivate an existing
+	// inactive project without re-uploading the SBOM (e.g. a rollback to a
+	// previously deployed image with a matching digest).
+	project, skipUpload := dtrack.Project{}, false
+	if g.manageProjectActiveStatus {
+		existing, lookupErr := client.Project.Lookup(context.Background(), projectName, version)
+		if lookupErr == nil && !existing.Active && getRawImageId(existing.Tags) == ctx.Image.ImageID {
+			project = existing
+			skipUpload = true
+			logrus.Infof("Reactivating existing project %s:%s without re-uploading SBOM", projectName, version)
+		}
 	}
 
-	logrus.Infof("Uploaded SBOM (upload-token=%s)", uploadToken)
+	if !skipUpload {
+		logrus.Infof("Sending SBOM to Dependency Track (project=%s, version=%s)", projectName, version)
+		uploadToken, err := client.BOM.PostBom(
+			context.Background(),
+			dtrack.BOMUploadRequest{ProjectName: projectName, ProjectVersion: version, AutoCreate: true, BOM: ctx.Sbom},
+		)
+		if err != nil {
+			logrus.Errorf("Could not upload BOM: %v", err)
+			return err
+		}
+		logrus.Infof("Uploaded SBOM (upload-token=%s)", uploadToken)
+	}
 
-	project, err := client.Project.Lookup(context.Background(), projectName, version)
-	if err != nil {
-		logrus.Errorf("Could not find project: %v", err)
-		return err
+	if !skipUpload {
+		project, err = client.Project.Lookup(context.Background(), projectName, version)
+		if err != nil {
+			logrus.Errorf("Could not find project: %v", err)
+			return err
+		}
 	}
 
 	kubernetesClusterTag := kubernetesCluster + "=" + g.k8sClusterId
@@ -257,9 +283,18 @@ func (g *DependencyTrackTarget) ProcessSbom(ctx *target.TargetContext) error {
 		project.ParentRef = &dtrack.ParentRef{UUID: *g.defaultParentProjectParsed}
 	}
 
+	if g.manageProjectActiveStatus {
+		project.Active = true
+		project.IsLatest = dtrack.OptionalBoolOf(true)
+	}
+
 	_, err = client.Project.Update(context.Background(), project)
 	if err != nil {
 		logrus.WithError(err).Errorf("Could not update project")
+	}
+
+	if g.manageProjectActiveStatus {
+		g.deactivateSiblingVersions(client, project)
 	}
 
 	if g.imageProjectMap == nil {
@@ -331,6 +366,13 @@ func (g *DependencyTrackTarget) LoadImages() ([]*libk8s.RegistryImage, error) {
 				if strings.Index(tag.Name, rawImageId) == 0 {
 					imageId = string(tag.Name[len(rawImageId)+1:])
 				}
+			}
+
+			// When active-status management is enabled, inactive projects are not
+			// returned so they neither appear as orphans on every cycle nor block
+			// re-scanning of a rolled-back image.
+			if g.manageProjectActiveStatus && !project.Active {
+				continue
 			}
 
 			if imageRelatesToCluster && sbomOperatorPropFound && len(imageId) > 0 {
@@ -434,6 +476,130 @@ func (g *DependencyTrackTarget) Remove(images []*libk8s.RegistryImage) error {
 	return nil
 }
 
+// Deactivate sets the given projects as inactive (and not latest) instead of
+// deleting them, preserving them for version history. Only invoked when
+// ShouldDeactivateOrphans returns true. All tags are kept.
+func (g *DependencyTrackTarget) Deactivate(images []*libk8s.RegistryImage) error {
+	if g.imageProjectMap == nil {
+		_, err := g.LoadImages()
+		if err != nil {
+			return err
+		}
+	}
+
+	client, err := dtrack.NewClient(g.baseUrl, g.clientOptions...)
+	if err != nil {
+		logrus.WithError(err).Errorf("failed to init dtrack client")
+		return err
+	}
+
+	for _, img := range images {
+		uuid := g.imageProjectMap[img.ImageID]
+		if uuid.String() == "00000000-0000-0000-0000-000000000000" {
+			logrus.Warnf("No project found for imageID: %s", img.ImageID)
+			continue
+		}
+
+		project, err := client.Project.Get(context.Background(), uuid)
+		if err != nil {
+			logrus.Errorf("Could not load project: %v", err)
+			continue
+		}
+
+		sbomOperatorPropFound := false
+		for _, tag := range project.Tags {
+			if tag.Name == sbomOperator {
+				sbomOperatorPropFound = true
+				break
+			}
+		}
+		if !sbomOperatorPropFound {
+			continue
+		}
+
+		if g.k8sClusterIdMode == "tag" {
+			// Tag mode: remove the current cluster tag and only deactivate if no
+			// other cluster is still using this project. This avoids deactivating
+			// a project that other clusters still run.
+			otherClusterIds := []string{}
+			for _, tag := range project.Tags {
+				if strings.Index(tag.Name, kubernetesCluster) == 0 {
+					clusterId := string(tag.Name[len(kubernetesCluster)+1:])
+					if clusterId == g.k8sClusterId {
+						logrus.Infof("Removing %v=%v tag from project %v:%v", kubernetesCluster, g.k8sClusterId, project.Name, project.Version)
+						project.Tags = removeTag(project.Tags, kubernetesCluster+"="+g.k8sClusterId)
+					} else {
+						otherClusterIds = append(otherClusterIds, clusterId)
+					}
+				}
+			}
+
+			if len(otherClusterIds) > 0 {
+				_, err := client.Project.Update(context.Background(), project)
+				delete(g.imageProjectMap, img.ImageID)
+				if err != nil {
+					logrus.WithError(err).Warnf("Project %s could not be updated", project.UUID.String())
+				}
+				continue
+			}
+		}
+
+		logrus.Infof("Image not running in any cluster - deactivating %v:%v", project.Name, project.Version)
+		_, err = client.Project.Patch(context.Background(), project.UUID, dtrack.Project{
+			Active:   false,
+			IsLatest: dtrack.OptionalBoolOf(false),
+		})
+		if err != nil {
+			logrus.WithError(err).Warnf("Project %s could not be deactivated", project.UUID.String())
+		}
+	}
+
+	return nil
+}
+
+func (g *DependencyTrackTarget) ShouldDeactivateOrphans() bool {
+	return g.manageProjectActiveStatus
+}
+
+// deactivateSiblingVersions sets all other versions of the same project name
+// under the same parent as inactive (and not latest), so that only the currently
+// running version stays active.
+func (g *DependencyTrackTarget) deactivateSiblingVersions(client *dtrack.Client, project dtrack.Project) {
+	if project.ParentRef == nil {
+		return
+	}
+
+	siblings, err := client.Project.GetProjectsForName(context.Background(), project.Name, false, false)
+	if err != nil {
+		logrus.WithError(err).Errorf("Could not load sibling projects for name %s", project.Name)
+		return
+	}
+
+	for _, sibling := range siblings {
+		if sibling.UUID == project.UUID {
+			continue
+		}
+		if sibling.ParentRef == nil || sibling.ParentRef.UUID != project.ParentRef.UUID {
+			continue
+		}
+		if sibling.Version == project.Version {
+			continue
+		}
+		if !containsTag(sibling.Tags, sbomOperator) {
+			continue
+		}
+
+		logrus.Infof("Deactivating sibling version %s:%s under parent %s", sibling.Name, sibling.Version, project.ParentRef.UUID)
+		_, err := client.Project.Patch(context.Background(), sibling.UUID, dtrack.Project{
+			Active:   false,
+			IsLatest: dtrack.OptionalBoolOf(false),
+		})
+		if err != nil {
+			logrus.WithError(err).Warnf("Sibling project %s:%s could not be deactivated", sibling.Name, sibling.Version)
+		}
+	}
+}
+
 func getNameAndVersionFromString(input string, delimiter string) (string, string) {
 	parts := strings.Split(input, delimiter)
 	name := parts[0]
@@ -470,6 +636,18 @@ func removeTag(tags []dtrack.Tag, tagString string) []dtrack.Tag {
 		}
 	}
 	return newTags
+}
+
+// getRawImageId returns the value of the first `raw-image-id=<id>` tag, or an
+// empty string if none is present.
+func getRawImageId(tags []dtrack.Tag) string {
+	prefix := rawImageId + "="
+	for _, tag := range tags {
+		if strings.HasPrefix(tag.Name, prefix) {
+			return strings.TrimPrefix(tag.Name, prefix)
+		}
+	}
+	return ""
 }
 
 // rotateRawImageIdTag drops any existing `raw-image-id=*` tag(s) from the slice

--- a/internal/target/dtrack/dtrack_target_test.go
+++ b/internal/target/dtrack/dtrack_target_test.go
@@ -1,6 +1,7 @@
 package dtrack
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -125,7 +126,7 @@ func TestGetContainerNameFromAnnotationKey(t *testing.T) {
 }
 
 func TestNewDependencyTrackTarget(t *testing.T) {
-	target := NewDependencyTrackTarget("url", "api", "matcher", "ca", "cert", "key", "cluster", "tag", "parent", "p-ann", "n-ann", true)
+	target := NewDependencyTrackTarget("url", "api", "matcher", "ca", "cert", "key", "cluster", "tag", "parent", "p-ann", "n-ann", true, true)
 	assert.Equal(t, "url", target.baseUrl)
 	assert.Equal(t, "api", target.apiKey)
 	assert.Equal(t, "matcher", target.podLabelTagMatcher)
@@ -138,6 +139,7 @@ func TestNewDependencyTrackTarget(t *testing.T) {
 	assert.Equal(t, "p-ann", target.parentProjectAnnotationKey)
 	assert.Equal(t, "n-ann", target.projectNameAnnotationKey)
 	assert.True(t, target.useShortName)
+	assert.True(t, target.manageProjectActiveStatus)
 }
 
 func TestInitialize(t *testing.T) {
@@ -200,6 +202,35 @@ func TestValidateConfig(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Manage active status without parent project",
+			target: &DependencyTrackTarget{
+				baseUrl:                   "http://localhost:8080",
+				apiKey:                    "apikey",
+				manageProjectActiveStatus: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Manage active status with default parent",
+			target: &DependencyTrackTarget{
+				baseUrl:                   "http://localhost:8080",
+				apiKey:                    "apikey",
+				defaultParentProject:      "8c940608-8e62-431a-ac5d-2092b7c41372",
+				manageProjectActiveStatus: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Manage active status with parent annotation key",
+			target: &DependencyTrackTarget{
+				baseUrl:                    "http://localhost:8080",
+				apiKey:                     "apikey",
+				parentProjectAnnotationKey: "example.com/parent",
+				manageProjectActiveStatus:  true,
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -219,14 +250,18 @@ func TestProcessSbomMinimal(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if r.URL.Path == "/api/v1/project" {
-			_, _ = w.Write([]byte("[]"))
+			if r.Method == "POST" {
+				_, _ = w.Write([]byte("{}"))
+			} else {
+				_, _ = w.Write([]byte("[]"))
+			}
 			return
 		}
 		_, _ = w.Write([]byte("{\"version\": \"4.8.0\", \"token\": \"uuid-token\", \"name\": \"alpine\", \"version\": \"3.14\", \"uuid\": \"8c940608-8e62-431a-ac5d-2092b7c41372\", \"totalCount\": 0}"))
 	}))
 	defer ts.Close()
 
-	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "", "", true)
+	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "", "", true, false)
 	err := g.Initialize()
 	assert.NoError(t, err)
 
@@ -252,7 +287,7 @@ func TestRemoveMinimal(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "", "", true)
+	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "", "", true, false)
 	err := g.Initialize()
 	assert.NoError(t, err)
 
@@ -350,7 +385,7 @@ func TestLoadImagesResetsImageProjectMap(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "", "", true)
+	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "", "", true, false)
 	err := g.Initialize()
 	assert.NoError(t, err)
 
@@ -395,9 +430,302 @@ func TestLoadImagesTagMode(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "", "", true)
+	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "", "", true, false)
 	err := g.Initialize()
 	assert.NoError(t, err)
 
 	_, _ = g.LoadImages()
+}
+
+func TestGetRawImageId(t *testing.T) {
+	assert.Equal(t, "", getRawImageId([]dtrack.Tag{{Name: "sbom-operator"}}))
+	assert.Equal(t, "alpine@sha256:aaa", getRawImageId([]dtrack.Tag{{Name: "raw-image-id=alpine@sha256:aaa"}}))
+	assert.Equal(t, "alpine@sha256:bbb", getRawImageId([]dtrack.Tag{
+		{Name: "sbom-operator"},
+		{Name: "raw-image-id=alpine@sha256:bbb"},
+		{Name: "namespace=default"},
+	}))
+}
+
+// TestProcessSbomReactivateWithoutUpload verifies the lookup-first optimization:
+// when an inactive project already exists with a matching raw-image-id, the BOM is
+// not re-uploaded and the project is reactivated instead.
+func TestProcessSbomReactivateWithoutUpload(t *testing.T) {
+	var postBomCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch r.URL.Path {
+		case "/api/v1/version":
+			_, _ = w.Write([]byte(`{"version": "5.0.0"}`))
+		case "/api/v1/project/lookup":
+			// existing inactive project with matching raw-image-id
+			_, _ = w.Write([]byte(`{
+				"name": "library/alpine", "version": "3.13", "active": false,
+				"uuid": "11111111-2222-3333-4444-555555555555",
+				"parent": {"uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"},
+				"tags": [{"name": "sbom-operator"}, {"name": "raw-image-id=alpine:3.13"}]
+			}`))
+		case "/api/v1/bom":
+			postBomCount++
+			_, _ = w.Write([]byte(`{"token": "tok"}`))
+		case "/api/v1/project":
+			if r.Method == "POST" {
+				_, _ = w.Write([]byte(`{}`))
+			} else {
+				_, _ = w.Write([]byte(`[]`))
+			}
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer ts.Close()
+
+	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "8c940608-8e62-431a-ac5d-2092b7c41372", "", true, true)
+	err := g.Initialize()
+	assert.NoError(t, err)
+
+	ctx := &target.TargetContext{
+		Image:     &liboci.RegistryImage{ImageID: "alpine:3.13", Image: "alpine:3.13"},
+		Pod:       &libk8s_real.PodInfo{PodNamespace: "default"},
+		Container: &libk8s_real.ContainerInfo{Name: "alpine"},
+		Sbom:      "{}",
+	}
+
+	_ = g.ProcessSbom(ctx)
+	assert.Equal(t, 0, postBomCount, "BOM must not be re-uploaded when reactivating an existing project")
+}
+
+// TestProcessSbomDeactivatesSiblings verifies that uploading a new version causes
+// sibling versions under the same parent to be patched as inactive.
+func TestProcessSbomDeactivatesSiblings(t *testing.T) {
+	parentUUID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	activeUUID := "11111111-2222-3333-4444-555555555555"
+	siblingUUID := "66666666-7777-8888-9999-000000000000"
+	untaggedSiblingUUID := "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+
+	var patchUUIDs []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch r.URL.Path {
+		case "/api/v1/version":
+			_, _ = w.Write([]byte(`{"version": "5.0.0"}`))
+		case "/api/v1/project/lookup":
+			_, _ = w.Write([]byte(`{
+				"name": "library/alpine", "version": "3.14", "active": true,
+				"uuid": "` + activeUUID + `",
+				"parent": {"uuid": "` + parentUUID + `"},
+				"tags": [{"name": "sbom-operator"}]
+			}`))
+		case "/api/v1/bom":
+			_, _ = w.Write([]byte(`{"token": "tok"}`))
+		case "/api/v1/project":
+			if r.Method == "POST" {
+				_, _ = w.Write([]byte(`{}`))
+			} else if r.URL.Query().Get("name") != "" {
+				// GetProjectsForName returns the current version + a sibling version
+				_, _ = w.Write([]byte(`[
+					{"name": "library/alpine", "version": "3.14", "active": true,
+					 "uuid": "` + activeUUID + `", "parent": {"uuid": "` + parentUUID + `"},
+					 "tags": [{"name": "sbom-operator"}]},
+					{"name": "library/alpine", "version": "3.13", "active": true,
+					 "uuid": "` + siblingUUID + `", "parent": {"uuid": "` + parentUUID + `"},
+					 "tags": [{"name": "sbom-operator"}]},
+					{"name": "library/alpine", "version": "3.12", "active": true,
+					 "uuid": "` + untaggedSiblingUUID + `", "parent": {"uuid": "` + parentUUID + `"},
+					 "tags": []}
+				]`))
+			} else {
+				_, _ = w.Write([]byte(`[]`))
+			}
+		default:
+			if r.Method == "PATCH" {
+				patchUUIDs = append(patchUUIDs, strings.TrimPrefix(r.URL.Path, "/api/v1/project/"))
+				_, _ = w.Write([]byte(`{}`))
+			} else {
+				_, _ = w.Write([]byte(`{}`))
+			}
+		}
+	}))
+	defer ts.Close()
+
+	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "8c940608-8e62-431a-ac5d-2092b7c41372", "", true, true)
+	err := g.Initialize()
+	assert.NoError(t, err)
+
+	ctx := &target.TargetContext{
+		Image:     &liboci.RegistryImage{ImageID: "alpine:3.14", Image: "alpine:3.14"},
+		Pod:       &libk8s_real.PodInfo{PodNamespace: "default"},
+		Container: &libk8s_real.ContainerInfo{Name: "alpine"},
+		Sbom:      "{}",
+	}
+
+	_ = g.ProcessSbom(ctx)
+	// Only the sbom-operator-tagged sibling should be patched as inactive. Neither
+	// the current project nor the untagged sibling may be touched.
+	assert.Equal(t, []string{siblingUUID}, patchUUIDs)
+}
+
+// TestDeactivate verifies that Deactivate patches projects as inactive instead of
+// deleting them.
+func TestDeactivate(t *testing.T) {
+	projectUUID := "11111111-2222-3333-4444-555555555555"
+	var patchCount, deleteCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch {
+		case r.URL.Path == "/api/v1/version":
+			_, _ = w.Write([]byte(`{"version": "5.0.0"}`))
+		case r.URL.Path == "/api/v1/project" && r.Method == "GET":
+			_, _ = w.Write([]byte(`[{
+				"name": "library/alpine", "version": "3.13", "active": true,
+				"uuid": "` + projectUUID + `",
+				"tags": [
+					{"name": "kubernetes-cluster=my-cluster"},
+					{"name": "sbom-operator"},
+					{"name": "raw-image-id=alpine:3.13"}
+				]
+			}]`))
+		case r.URL.Path == "/api/v1/project/"+projectUUID && r.Method == "GET":
+			_, _ = w.Write([]byte(`{
+				"name": "library/alpine", "version": "3.13", "active": true,
+				"uuid": "` + projectUUID + `",
+				"tags": [{"name": "sbom-operator"}, {"name": "raw-image-id=alpine:3.13"}]
+			}`))
+		case strings.HasPrefix(r.URL.Path, "/api/v1/project/") && r.Method == "PATCH":
+			patchCount++
+			_, _ = w.Write([]byte(`{}`))
+		case strings.HasPrefix(r.URL.Path, "/api/v1/project/") && r.Method == "DELETE":
+			deleteCount++
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer ts.Close()
+
+	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "", "", true, true)
+	err := g.Initialize()
+	assert.NoError(t, err)
+
+	images := []*liboci.RegistryImage{{ImageID: "alpine:3.13", Image: "alpine:3.13"}}
+	_ = g.Deactivate(images)
+	assert.Equal(t, 1, patchCount, "project should be patched as inactive")
+	assert.Equal(t, 0, deleteCount, "project must not be deleted")
+	assert.True(t, g.ShouldDeactivateOrphans())
+}
+
+// TestDeactivateTagModeMultiCluster verifies that in tag mode, Deactivate removes
+// the current cluster's tag but does NOT deactivate the project when another
+// cluster is still using it.
+func TestDeactivateTagModeMultiCluster(t *testing.T) {
+	projectUUID := "11111111-2222-3333-4444-555555555555"
+	var patchCount int
+	var updateBodies []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch {
+		case r.URL.Path == "/api/v1/version":
+			_, _ = w.Write([]byte(`{"version": "5.0.0"}`))
+		case r.URL.Path == "/api/v1/project" && r.Method == "GET":
+			// LoadImages returns the project tagged for both my-cluster and other-cluster
+			_, _ = w.Write([]byte(`[{
+				"name": "library/alpine", "version": "3.13", "active": true,
+				"uuid": "` + projectUUID + `",
+				"tags": [
+					{"name": "kubernetes-cluster=my-cluster"},
+					{"name": "kubernetes-cluster=other-cluster"},
+					{"name": "sbom-operator"},
+					{"name": "raw-image-id=alpine:3.13"}
+				]
+			}]`))
+		case r.URL.Path == "/api/v1/project/"+projectUUID && r.Method == "GET":
+			_, _ = w.Write([]byte(`{
+				"name": "library/alpine", "version": "3.13", "active": true,
+				"uuid": "` + projectUUID + `",
+				"tags": [
+					{"name": "kubernetes-cluster=my-cluster"},
+					{"name": "kubernetes-cluster=other-cluster"},
+					{"name": "sbom-operator"},
+					{"name": "raw-image-id=alpine:3.13"}
+				]
+			}`))
+		case strings.HasPrefix(r.URL.Path, "/api/v1/project/") && r.Method == "PATCH":
+			patchCount++
+			_, _ = w.Write([]byte(`{}`))
+		case r.URL.Path == "/api/v1/project" && r.Method == "POST":
+			body, _ := io.ReadAll(r.Body)
+			updateBodies = append(updateBodies, string(body))
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer ts.Close()
+
+	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "", "", true, true)
+	err := g.Initialize()
+	assert.NoError(t, err)
+
+	images := []*liboci.RegistryImage{{ImageID: "alpine:3.13", Image: "alpine:3.13"}}
+	_ = g.Deactivate(images)
+
+	// Project must NOT be patched as inactive because another cluster still uses it.
+	assert.Equal(t, 0, patchCount, "project must not be deactivated while another cluster uses it")
+
+	// The cluster tag for my-cluster must have been removed in the Update body.
+	assert.Len(t, updateBodies, 1)
+	assert.Contains(t, updateBodies[0], `"kubernetes-cluster=other-cluster"`)
+	assert.NotContains(t, updateBodies[0], `"kubernetes-cluster=my-cluster"`)
+}
+
+// TestLoadImagesSkipsInactiveProjects verifies that inactive projects are not
+// returned when active-status management is enabled, so they don't surface as
+// orphans and rolled-back images get re-scanned.
+func TestLoadImagesSkipsInactiveProjects(t *testing.T) {
+	activeUUID := "11111111-2222-3333-4444-555555555555"
+	inactiveUUID := "66666666-7777-8888-9999-000000000000"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Path == "/api/v1/project" && r.Method == "GET" {
+			_, _ = w.Write([]byte(`[
+				{"name": "library/alpine", "version": "3.14", "active": true,
+				 "uuid": "` + activeUUID + `",
+				 "tags": [
+					{"name": "kubernetes-cluster=my-cluster"},
+					{"name": "sbom-operator"},
+					{"name": "raw-image-id=alpine:3.14"}
+				 ]},
+				{"name": "library/alpine", "version": "3.13", "active": false,
+				 "uuid": "` + inactiveUUID + `",
+				 "tags": [
+					{"name": "kubernetes-cluster=my-cluster"},
+					{"name": "sbom-operator"},
+					{"name": "raw-image-id=alpine:3.13"}
+				 ]}
+			]`))
+			return
+		}
+		if r.URL.Path == "/api/v1/version" {
+			_, _ = w.Write([]byte(`{"version": "5.0.0"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"totalCount": 1}`))
+	}))
+	defer ts.Close()
+
+	g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "", "", true, true)
+	err := g.Initialize()
+	assert.NoError(t, err)
+
+	images, err := g.LoadImages()
+	assert.NoError(t, err)
+	assert.Len(t, images, 1)
+	assert.Equal(t, "alpine:3.14", images[0].ImageID)
+	_, inactivePresent := g.imageProjectMap["alpine:3.13"]
+	assert.False(t, inactivePresent, "inactive project must not populate imageProjectMap")
 }

--- a/internal/target/dtrack/dtrack_target_test.go
+++ b/internal/target/dtrack/dtrack_target_test.go
@@ -503,6 +503,7 @@ func TestProcessSbomDeactivatesSiblings(t *testing.T) {
 	activeUUID := "11111111-2222-3333-4444-555555555555"
 	siblingUUID := "66666666-7777-8888-9999-000000000000"
 	untaggedSiblingUUID := "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+	inactiveSiblingUUID := "88888888-9999-aaaa-bbbb-cccccccccccc"
 
 	var patchUUIDs []string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -534,7 +535,10 @@ func TestProcessSbomDeactivatesSiblings(t *testing.T) {
 					 "tags": [{"name": "sbom-operator"}]},
 					{"name": "library/alpine", "version": "3.12", "active": true,
 					 "uuid": "` + untaggedSiblingUUID + `", "parent": {"uuid": "` + parentUUID + `"},
-					 "tags": []}
+					 "tags": []},
+					{"name": "library/alpine", "version": "3.11", "active": false,
+					 "uuid": "` + inactiveSiblingUUID + `", "parent": {"uuid": "` + parentUUID + `"},
+					 "tags": [{"name": "sbom-operator"}]}
 				]`))
 			} else {
 				_, _ = w.Write([]byte(`[]`))
@@ -562,8 +566,9 @@ func TestProcessSbomDeactivatesSiblings(t *testing.T) {
 	}
 
 	_ = g.ProcessSbom(ctx)
-	// Only the sbom-operator-tagged sibling should be patched as inactive. Neither
-	// the current project nor the untagged sibling may be touched.
+	// Only the active, sbom-operator-tagged sibling should be patched as inactive.
+	// The current project, the untagged sibling, and the already-inactive sibling
+	// must not be touched.
 	assert.Equal(t, []string{siblingUUID}, patchUUIDs)
 }
 
@@ -571,6 +576,7 @@ func TestProcessSbomDeactivatesSiblings(t *testing.T) {
 // deleting them.
 func TestDeactivate(t *testing.T) {
 	projectUUID := "11111111-2222-3333-4444-555555555555"
+	inactiveUUID := "88888888-9999-aaaa-bbbb-cccccccccccc"
 	var patchCount, deleteCount int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -578,21 +584,17 @@ func TestDeactivate(t *testing.T) {
 		switch {
 		case r.URL.Path == "/api/v1/version":
 			_, _ = w.Write([]byte(`{"version": "5.0.0"}`))
-		case r.URL.Path == "/api/v1/project" && r.Method == "GET":
-			_, _ = w.Write([]byte(`[{
-				"name": "library/alpine", "version": "3.13", "active": true,
-				"uuid": "` + projectUUID + `",
-				"tags": [
-					{"name": "kubernetes-cluster=my-cluster"},
-					{"name": "sbom-operator"},
-					{"name": "raw-image-id=alpine:3.13"}
-				]
-			}]`))
 		case r.URL.Path == "/api/v1/project/"+projectUUID && r.Method == "GET":
 			_, _ = w.Write([]byte(`{
 				"name": "library/alpine", "version": "3.13", "active": true,
 				"uuid": "` + projectUUID + `",
 				"tags": [{"name": "sbom-operator"}, {"name": "raw-image-id=alpine:3.13"}]
+			}`))
+		case r.URL.Path == "/api/v1/project/"+inactiveUUID && r.Method == "GET":
+			_, _ = w.Write([]byte(`{
+				"name": "library/alpine", "version": "3.12", "active": false,
+				"uuid": "` + inactiveUUID + `",
+				"tags": [{"name": "sbom-operator"}, {"name": "raw-image-id=alpine:3.12"}]
 			}`))
 		case strings.HasPrefix(r.URL.Path, "/api/v1/project/") && r.Method == "PATCH":
 			patchCount++
@@ -610,9 +612,20 @@ func TestDeactivate(t *testing.T) {
 	err := g.Initialize()
 	assert.NoError(t, err)
 
-	images := []*liboci.RegistryImage{{ImageID: "alpine:3.13", Image: "alpine:3.13"}}
+	// Seed the map directly with one active and one already-inactive project.
+	g.imageProjectMap = map[string]uuid.UUID{
+		"alpine:3.13": uuid.MustParse(projectUUID),
+		"alpine:3.12": uuid.MustParse(inactiveUUID),
+	}
+
+	images := []*liboci.RegistryImage{
+		{ImageID: "alpine:3.13", Image: "alpine:3.13"},
+		{ImageID: "alpine:3.12", Image: "alpine:3.12"},
+	}
 	_ = g.Deactivate(images)
-	assert.Equal(t, 1, patchCount, "project should be patched as inactive")
+	// Only the active project should be patched as inactive; the already-inactive
+	// one must be skipped (no 304 PATCH).
+	assert.Equal(t, 1, patchCount, "only the active project should be patched as inactive")
 	assert.Equal(t, 0, deleteCount, "project must not be deleted")
 	assert.True(t, g.ShouldDeactivateOrphans())
 }

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -20,6 +20,16 @@ type Target interface {
 	Remove(images []*oci.RegistryImage) error
 }
 
+// DeactivateTarget is an optional extension of Target for backends that can
+// deactivate (rather than delete) orphaned images. When ShouldDeactivateOrphans
+// returns true, the processor calls Deactivate instead of Remove during orphan
+// cleanup, regardless of the global delete-orphan-images flag.
+type DeactivateTarget interface {
+	Target
+	Deactivate(images []*oci.RegistryImage) error
+	ShouldDeactivateOrphans() bool
+}
+
 func NewContext(sbom string, image *oci.RegistryImage, container *libk8s.ContainerInfo, pod *libk8s.PodInfo) *TargetContext {
 	return &TargetContext{image, container, pod, sbom}
 }

--- a/main.go
+++ b/main.go
@@ -117,6 +117,7 @@ func newRootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().String(internal.ConfigKeyDependencyTrackDtrackParentProjectAnnotationKey, "", "Dependency-Track: kubernetes annotation-key for setting parent project")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyDependencyTrackDtrackProjectNameAnnotationKey, "", "Dependency-Track: kubernetes annotation-key for setting custom project name")
 	rootCmd.PersistentFlags().Bool(internal.ConfigKeyDependencyTrackUseShortName, false, "Dependency-Track: use short image name (without registry) for project names")
+	rootCmd.PersistentFlags().Bool(internal.ConfigKeyDependencyTrackManageProjectActiveStatus, false, "Dependency-Track: manage project active/isLatest status based on running pods. When enabled, orphaned projects are deactivated instead of deleted (the global --delete-orphan-images flag is bypassed for dtrack). Requires a parent project (--dtrack-parent-project-annotation-key or --dtrack-default-parent-project).")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyKubernetesClusterId, "default", "Kubernetes Cluster ID")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyJobImage, "", "Custom Job-Image")
 	rootCmd.PersistentFlags().String(internal.ConfigKeyJobImagePullSecret, "", "Custom Job-Image-Pull-Secret")


### PR DESCRIPTION
## Summary

Add `--dtrack-manage-project-active-status` flag for Dependency Track project lifecycle management.

When enabled, the operator keeps DT project active/isLatest state in sync with what's actually running in the cluster:
- Running version → `Active=true`, `IsLatest=true`
- Other active versions under the same parent → deactivated
- Orphans (no longer running) → deactivated instead of deleted, preserving history
- Rollback to a previous image with matching digest → reactivated without re-uploading the BOM

Requires a parent project (`--dtrack-parent-project-annotation-key` or `--dtrack-default-parent-project`) and DT v4.12.0+ (released in Oct. 2024) for `isLatest`. 

Multi-cluster tag mode is handled — only deactivates when no other cluster still uses the project.

When disabled (default), existing behavior is unchanged.

---

Closes #980 

_Contribution made with the help of OpenCode._