### PR TITLE
test(internal/dtrack): fix missing parameter

### DIFF
--- a/internal/target/dtrack/dtrack_target_test.go
+++ b/internal/target/dtrack/dtrack_target_test.go
@@ -333,7 +333,7 @@ func TestProcessSbomParentProject(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "my.parent.project", "", true)
+			g := NewDependencyTrackTarget(ts.URL, "apikey", "", "", "", "", "my-cluster", "tag", "", "my.parent.project", "", true, false)
 			err := g.Initialize()
 			assert.NoError(t, err)
 			// Pre-populate so LoadImages is skipped during ProcessSbom.


### PR DESCRIPTION
Fixes [failing CI **test** job](https://github.com/ckotzbauer/sbom-operator/actions/runs/32580221966/job/97048346840) after #981 merge